### PR TITLE
Fix npm publish workflow and automate releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,23 @@ jobs:
       - name: Build server entries
         run: npm run build:server
 
+      - name: Determine npm tag
+        id: npm-tag
+        run: |
+          # Extract version from package.json
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Version: $VERSION"
+          
+          # Check if it's a prerelease version (contains alpha, beta, rc, etc.)
+          if [[ "$VERSION" =~ (alpha|beta|rc|pre) ]]; then
+            echo "NPM_TAG=alpha" >> $GITHUB_OUTPUT
+            echo "Publishing as alpha tag"
+          else
+            echo "NPM_TAG=latest" >> $GITHUB_OUTPUT
+            echo "Publishing as latest tag"
+          fi
+
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --tag alpha
+        run: npm publish --tag ${{ steps.npm-tag.outputs.NPM_TAG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,3 +64,65 @@ jobs:
             client-public.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-npm:
+    name: Publish to npm
+    needs: [release-please, build-and-attach]
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org/'
+          always-auth: true
+
+      - name: Verify npm token
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN}" ]; then
+            echo "NPM_TOKEN is not set (add repo secret NPM_TOKEN)" && exit 1
+          fi
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+          npm whoami
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts=false
+
+      - name: Build client
+        run: npm run build
+
+      - name: Build server entries
+        run: npm run build:server
+
+      - name: Determine npm tag
+        id: npm-tag
+        run: |
+          # Extract version from package.json
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Version: $VERSION"
+          
+          # Check if it's a prerelease version (contains alpha, beta, rc, etc.)
+          if [[ "$VERSION" =~ (alpha|beta|rc|pre) ]]; then
+            echo "NPM_TAG=alpha" >> $GITHUB_OUTPUT
+            echo "Publishing as alpha tag"
+          else
+            echo "NPM_TAG=latest" >> $GITHUB_OUTPUT
+            echo "Publishing as latest tag"
+          fi
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --tag ${{ steps.npm-tag.outputs.NPM_TAG }}

--- a/fix-npm-tags.sh
+++ b/fix-npm-tags.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Script to fix npm dist-tags for webssh2_client
+
+echo "This script will fix the npm dist-tags for webssh2_client"
+echo "You'll need to provide your npm OTP when prompted"
+echo ""
+
+# Move v2.0.0 from alpha to latest
+echo "Moving v2.0.0 to latest tag..."
+npm dist-tag add webssh2_client@2.0.0 latest
+
+echo ""
+echo "Current dist-tags:"
+npm view webssh2_client dist-tags
+
+echo ""
+echo "Done! The dist-tags should now be:"
+echo "  latest: 2.0.0"
+echo "  alpha: (should point to latest alpha version if any)"


### PR DESCRIPTION
## Summary
- Fixed npm publishing workflow to handle stable vs prerelease versions correctly
- Added automatic npm publishing when release-please creates a release
- Created script to fix current npm dist-tags

## Problems Fixed
1. **v2.0.0 was published with `alpha` tag instead of `latest`** - The workflow was hardcoded to always use `--tag alpha`
2. **Publish workflow didn't trigger automatically** - Release-please creates releases but publish workflow only listened for manual triggers
3. **No automatic npm publishing** - Required manual workflow dispatch after each release

## Changes
### `.github/workflows/publish.yml`
- Added logic to dynamically determine npm tag based on version
- Prereleases (containing alpha/beta/rc) publish with `alpha` tag
- Stable releases publish with `latest` tag

### `.github/workflows/release.yml` 
- Added `publish-npm` job that runs after release-please creates a release
- Automatically publishes to npm with correct dist-tag
- Maintains same build and verification steps as manual workflow

### `fix-npm-tags.sh`
- Script to manually fix the current npm dist-tags
- Moves v2.0.0 from `alpha` to `latest` tag
- Run with: `./fix-npm-tags.sh` (requires npm OTP)

## Test Plan
- [x] Workflow syntax is valid
- [ ] Next prerelease will publish with `alpha` tag
- [ ] Next stable release will publish with `latest` tag
- [ ] Manual workflow dispatch still works as backup

## Note
After merging, run `./fix-npm-tags.sh` to fix the current npm dist-tags for v2.0.0.