### PR TITLE
feat: add custom terminal theme support

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -598,7 +598,10 @@ const App: Component = () => {
   }
 
   return (
-    <div class="flex size-full flex-col overflow-hidden bg-black text-neutral-100">
+    <div
+      id="terminal-app"
+      class="flex size-full flex-col overflow-hidden bg-black text-neutral-100"
+    >
       {/* Modals */}
       {(() => {
         // Build LoginModal props, conditionally including locked values

--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -7,10 +7,11 @@ import createDebug from 'debug'
 // Import the custom solid-xterm wrapper
 import { XTerm } from '../lib/xterm-solid/components/XTerm'
 import type { TerminalRef, XTermProps } from '../lib/xterm-solid/types'
-import type { Terminal, ITerminalOptions } from '@xterm/xterm'
+import type { Terminal, ITerminalOptions, ITheme } from '@xterm/xterm'
 
 // Import existing functionality
 import { validateNumber, defaultSettings } from '../utils/index.js'
+import { resolveTheme } from '../utils/themes.js'
 import {
   emitData,
   setTerminalDimensions,
@@ -30,6 +31,13 @@ import { ClipboardCompatibility } from '../utils/clipboard-compatibility'
 import { playBellSound } from '../utils/bell-sound.js'
 
 const debug = createDebug('webssh2-client:terminal-component')
+
+function syncContainerBackground(bg?: string): void {
+  const el = document.getElementById('terminal-app')
+  if (el) {
+    el.style.backgroundColor = bg || ''
+  }
+}
 
 // Reactive terminal actions interface
 export interface TerminalActions {
@@ -141,10 +149,20 @@ export const TerminalComponent: Component<TerminalComponentProps> = (props) => {
         storedSettings.lineHeight ??
         terminalConfig.lineHeight ??
         defaultSettings.lineHeight,
+      theme: resolveTheme(
+        String(
+          storedSettings.themeName ??
+            terminalConfig.themeName ??
+            defaultSettings.themeName
+        ),
+        (storedSettings.customTheme ??
+          terminalConfig.customTheme ??
+          null) as ITheme | null
+      ),
       allowProposedApi: true // Required for SearchAddon decorations
     }
 
-    debug('getTerminalOptions', mergedOptions)
+    syncContainerBackground(mergedOptions.theme?.background)
     return mergedOptions
   }
 
@@ -285,7 +303,7 @@ export const TerminalComponent: Component<TerminalComponentProps> = (props) => {
         if (!currentRef?.terminal) return
 
         // Apply validated settings
-        const validatedSettings = {
+        const validatedSettings: Partial<ITerminalOptions> = {
           cursorBlink: options.cursorBlink ?? defaultSettings.cursorBlink,
           scrollback: validateNumber(
             options.scrollback ?? defaultSettings.scrollback,
@@ -308,6 +326,11 @@ export const TerminalComponent: Component<TerminalComponentProps> = (props) => {
           fontFamily: String(options.fontFamily ?? defaultSettings.fontFamily),
           letterSpacing: options.letterSpacing ?? defaultSettings.letterSpacing,
           lineHeight: options.lineHeight ?? defaultSettings.lineHeight
+        }
+
+        if (options.theme) {
+          validatedSettings.theme = options.theme
+          syncContainerBackground(options.theme.background)
         }
 
         Object.assign(currentRef.terminal.options, validatedSettings)
@@ -558,6 +581,11 @@ export class SolidTerminalManager {
       fontFamily: String(options.fontFamily ?? defaultSettings.fontFamily),
       letterSpacing: options.letterSpacing ?? defaultSettings.letterSpacing,
       lineHeight: options.lineHeight ?? defaultSettings.lineHeight
+    }
+
+    if (options.theme) {
+      terminalSettings.theme = options.theme
+      syncContainerBackground(options.theme.background)
     }
 
     Object.assign(this.terminalRef!.terminal!.options, terminalSettings)

--- a/client/src/components/TerminalSettingsModal.tsx
+++ b/client/src/components/TerminalSettingsModal.tsx
@@ -10,10 +10,15 @@ import {
   Upload,
   Plus
 } from 'lucide-solid'
-import type { ITerminalOptions } from '@xterm/xterm'
+import type { ITerminalOptions, ITheme } from '@xterm/xterm'
 import { getStoredSettings, saveTerminalSettings } from '../utils/settings.js'
 import { defaultSettings } from '../utils/index.js'
 import { playPromptSound } from '../utils/prompt-sounds.js'
+import {
+  getThemeNames,
+  resolveTheme,
+  validateThemeJson
+} from '../utils/themes.js'
 import type {
   TerminalSettings,
   KeyboardCaptureSettings,
@@ -67,6 +72,15 @@ export const TerminalSettingsModal: Component<TerminalSettingsModalProps> = (
   const [keyboardExpanded, setKeyboardExpanded] = createSignal(false)
   const [soundsExpanded, setSoundsExpanded] = createSignal(false)
   const [hostKeysExpanded, setHostKeysExpanded] = createSignal(false)
+  const [themeExpanded, setThemeExpanded] = createSignal(false)
+  const [selectedTheme, setSelectedTheme] = createSignal('Default')
+  const [customThemeJson, setCustomThemeJson] = createSignal('')
+  const [customThemeError, setCustomThemeError] = createSignal<string | null>(
+    null
+  )
+  const [customThemeParsed, setCustomThemeParsed] = createSignal<ITheme | null>(
+    null
+  )
 
   // Host key management state
   const [storedKeys, setStoredKeys] = createSignal<
@@ -183,6 +197,19 @@ export const TerminalSettingsModal: Component<TerminalSettingsModalProps> = (
             }
           : defaultSettings.promptSounds
       })
+      // Load theme settings
+      const themeName = (stored.themeName as string) || 'Default'
+      setSelectedTheme(themeName)
+      if (themeName === 'custom' && stored.customTheme) {
+        const themeObj = stored.customTheme as ITheme
+        setCustomThemeJson(JSON.stringify(themeObj, null, 2))
+        setCustomThemeParsed(themeObj)
+        setCustomThemeError(null)
+      } else {
+        setCustomThemeJson('')
+        setCustomThemeParsed(null)
+        setCustomThemeError(null)
+      }
     }
   })
 
@@ -196,6 +223,8 @@ export const TerminalSettingsModal: Component<TerminalSettingsModalProps> = (
   const handleSubmit = (e: Event) => {
     e.preventDefault()
     const currentSettings = settings()
+    const themeName = selectedTheme()
+    const customTheme = themeName === 'custom' ? customThemeParsed() : null
 
     // Convert to ITerminalOptions format
     const terminalOptions: Partial<ITerminalOptions> = {
@@ -203,11 +232,16 @@ export const TerminalSettingsModal: Component<TerminalSettingsModalProps> = (
       fontFamily: currentSettings.fontFamily,
       cursorBlink: currentSettings.cursorBlink,
       scrollback: currentSettings.scrollback,
-      tabStopWidth: currentSettings.tabStopWidth
+      tabStopWidth: currentSettings.tabStopWidth,
+      theme: resolveTheme(themeName, customTheme) ?? {}
     }
 
-    // Save settings
-    saveTerminalSettings(currentSettings as unknown as Record<string, unknown>)
+    // Save settings including theme
+    saveTerminalSettings({
+      ...(currentSettings as unknown as Record<string, unknown>),
+      themeName,
+      customTheme
+    })
 
     // Apply to terminal - pass ALL settings including clipboard, keyboard capture, and prompt sounds
     props.onSave({
@@ -366,6 +400,137 @@ export const TerminalSettingsModal: Component<TerminalSettingsModalProps> = (
                 <option value="none">None</option>
               </select>
             </label>
+
+            {/* Terminal Theme Section Header */}
+            <div class="col-span-full mb-2 mt-4 border-t pt-2">
+              <button
+                type="button"
+                class="flex w-full items-center justify-between text-sm font-semibold text-slate-900 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                onClick={() => setThemeExpanded(!themeExpanded())}
+                aria-expanded={themeExpanded()}
+              >
+                <span>Terminal Theme</span>
+                {themeExpanded() ? (
+                  <ChevronUp class="size-4" />
+                ) : (
+                  <ChevronDown class="size-4" />
+                )}
+              </button>
+            </div>
+
+            <Show when={themeExpanded()}>
+              {/* Theme Selector */}
+              <label class="contents">
+                <span class="whitespace-nowrap pr-3 text-sm font-medium text-slate-700 sm:text-right">
+                  Theme
+                </span>
+                <select
+                  name="themeName"
+                  class="block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  value={selectedTheme()}
+                  onChange={(e) => {
+                    const value = e.currentTarget.value
+                    setSelectedTheme(value)
+                    if (value !== 'custom') {
+                      setCustomThemeError(null)
+                    }
+                  }}
+                >
+                  <For each={getThemeNames()}>
+                    {(name) => <option value={name}>{name}</option>}
+                  </For>
+                  <option value="custom">Custom...</option>
+                </select>
+              </label>
+
+              {/* Color Preview */}
+              {(() => {
+                const previewTheme =
+                  selectedTheme() === 'custom'
+                    ? customThemeParsed()
+                    : resolveTheme(selectedTheme(), null)
+                if (!previewTheme || Object.keys(previewTheme).length === 0)
+                  return null
+                const colors = [
+                  { label: 'bg', value: previewTheme.background },
+                  { label: 'fg', value: previewTheme.foreground },
+                  { label: 'blk', value: previewTheme.black },
+                  { label: 'red', value: previewTheme.red },
+                  { label: 'grn', value: previewTheme.green },
+                  { label: 'yel', value: previewTheme.yellow },
+                  { label: 'blu', value: previewTheme.blue },
+                  { label: 'mag', value: previewTheme.magenta },
+                  { label: 'cyn', value: previewTheme.cyan },
+                  { label: 'wht', value: previewTheme.white }
+                ].filter((c) => c.value)
+                return (
+                  <div class="col-span-full flex flex-wrap gap-1 py-1">
+                    <For each={colors}>
+                      {(c) => (
+                        <div
+                          class="size-6 rounded border border-slate-300"
+                          style={{ 'background-color': c.value }}
+                          title={`${c.label}: ${c.value}`}
+                        />
+                      )}
+                    </For>
+                  </div>
+                )
+              })()}
+
+              {/* Custom Theme JSON */}
+              <Show when={selectedTheme() === 'custom'}>
+                <div class="col-span-full space-y-2">
+                  <p class="text-xs text-slate-600">
+                    Paste a theme JSON (Windows Terminal or xterm.js format).
+                    Find themes at{' '}
+                    <a
+                      href="https://windowsterminalthemes.dev"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="text-blue-600 underline"
+                    >
+                      windowsterminalthemes.dev
+                    </a>
+                  </p>
+                  <textarea
+                    rows={8}
+                    placeholder='{"background": "#282a36", "foreground": "#f8f8f2", ...}'
+                    class="block w-full rounded-md border border-slate-300 bg-white px-2 py-1.5 font-mono text-xs text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    value={customThemeJson()}
+                    onInput={(e) => {
+                      const json = e.currentTarget.value
+                      setCustomThemeJson(json)
+                      if (!json.trim()) {
+                        setCustomThemeError(null)
+                        setCustomThemeParsed(null)
+                        return
+                      }
+                      const result = validateThemeJson(json)
+                      if ('error' in result) {
+                        setCustomThemeError(result.error)
+                        setCustomThemeParsed(null)
+                      } else {
+                        setCustomThemeError(null)
+                        setCustomThemeParsed(result.theme)
+                      }
+                    }}
+                  />
+                  <Show when={customThemeError()}>
+                    <p class="text-xs text-red-600">{customThemeError()}</p>
+                  </Show>
+                  <Show
+                    when={
+                      !customThemeError() &&
+                      customThemeParsed() &&
+                      customThemeJson().trim()
+                    }
+                  >
+                    <p class="text-xs text-green-600">Theme is valid</p>
+                  </Show>
+                </div>
+              </Show>
+            </Show>
 
             {/* Clipboard Settings Section Header */}
             <div class="col-span-full mb-2 mt-4 border-t pt-2">

--- a/client/src/types/config.d.ts
+++ b/client/src/types/config.d.ts
@@ -1,3 +1,5 @@
+import type { ITheme } from '@xterm/xterm'
+
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
 
 export type SSHAuthMethod = 'password' | 'keyboard-interactive' | 'publickey'
@@ -35,6 +37,8 @@ export interface TerminalSettings {
   clipboardEnableKeyboardShortcuts: boolean
   keyboardCapture: KeyboardCaptureSettings
   promptSounds: PromptSoundSettings
+  themeName: string
+  customTheme: ITheme | null
 }
 
 export interface WebSocketConfig {

--- a/client/src/utils/index.ts
+++ b/client/src/utils/index.ts
@@ -44,7 +44,9 @@ export const defaultSettings: TerminalSettings = {
       error: true,
       success: true
     }
-  }
+  },
+  themeName: 'Default',
+  customTheme: null
 }
 
 export function validateNumber(

--- a/client/src/utils/themes.ts
+++ b/client/src/utils/themes.ts
@@ -1,0 +1,404 @@
+import type { ITheme } from '@xterm/xterm'
+
+export interface NamedTheme {
+  name: string
+  theme: ITheme
+}
+
+export interface WindowsTerminalTheme {
+  name?: string
+  background?: string
+  foreground?: string
+  cursorColor?: string
+  selectionBackground?: string
+  black?: string
+  red?: string
+  green?: string
+  yellow?: string
+  blue?: string
+  purple?: string
+  cyan?: string
+  white?: string
+  brightBlack?: string
+  brightRed?: string
+  brightGreen?: string
+  brightYellow?: string
+  brightBlue?: string
+  brightPurple?: string
+  brightCyan?: string
+  brightWhite?: string
+}
+
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{3,8}$/
+
+export const builtinThemes: NamedTheme[] = [
+  { name: 'Default', theme: {} },
+  {
+    name: 'Dracula',
+    theme: {
+      background: '#282a36',
+      foreground: '#f8f8f2',
+      cursor: '#f8f8f2',
+      selectionBackground: '#44475a',
+      black: '#21222c',
+      red: '#ff5555',
+      green: '#50fa7b',
+      yellow: '#f1fa8c',
+      blue: '#bd93f9',
+      magenta: '#ff79c6',
+      cyan: '#8be9fd',
+      white: '#f8f8f2',
+      brightBlack: '#6272a4',
+      brightRed: '#ff6e6e',
+      brightGreen: '#69ff94',
+      brightYellow: '#ffffa5',
+      brightBlue: '#d6acff',
+      brightMagenta: '#ff92df',
+      brightCyan: '#a4ffff',
+      brightWhite: '#ffffff'
+    }
+  },
+  {
+    name: 'Nord',
+    theme: {
+      background: '#2e3440',
+      foreground: '#d8dee9',
+      cursor: '#d8dee9',
+      selectionBackground: '#434c5e',
+      black: '#3b4252',
+      red: '#bf616a',
+      green: '#a3be8c',
+      yellow: '#ebcb8b',
+      blue: '#81a1c1',
+      magenta: '#b48ead',
+      cyan: '#88c0d0',
+      white: '#e5e9f0',
+      brightBlack: '#4c566a',
+      brightRed: '#bf616a',
+      brightGreen: '#a3be8c',
+      brightYellow: '#ebcb8b',
+      brightBlue: '#81a1c1',
+      brightMagenta: '#b48ead',
+      brightCyan: '#8fbcbb',
+      brightWhite: '#eceff4'
+    }
+  },
+  {
+    name: 'Solarized Dark',
+    theme: {
+      background: '#002b36',
+      foreground: '#839496',
+      cursor: '#839496',
+      selectionBackground: '#073642',
+      black: '#073642',
+      red: '#dc322f',
+      green: '#859900',
+      yellow: '#b58900',
+      blue: '#268bd2',
+      magenta: '#d33682',
+      cyan: '#2aa198',
+      white: '#eee8d5',
+      brightBlack: '#586e75',
+      brightRed: '#cb4b16',
+      brightGreen: '#586e75',
+      brightYellow: '#657b83',
+      brightBlue: '#839496',
+      brightMagenta: '#6c71c4',
+      brightCyan: '#93a1a1',
+      brightWhite: '#fdf6e3'
+    }
+  },
+  {
+    name: 'Solarized Light',
+    theme: {
+      background: '#fdf6e3',
+      foreground: '#657b83',
+      cursor: '#657b83',
+      selectionBackground: '#eee8d5',
+      black: '#073642',
+      red: '#dc322f',
+      green: '#859900',
+      yellow: '#b58900',
+      blue: '#268bd2',
+      magenta: '#d33682',
+      cyan: '#2aa198',
+      white: '#eee8d5',
+      brightBlack: '#002b36',
+      brightRed: '#cb4b16',
+      brightGreen: '#586e75',
+      brightYellow: '#657b83',
+      brightBlue: '#839496',
+      brightMagenta: '#6c71c4',
+      brightCyan: '#93a1a1',
+      brightWhite: '#fdf6e3'
+    }
+  },
+  {
+    name: 'One Dark',
+    theme: {
+      background: '#282c34',
+      foreground: '#abb2bf',
+      cursor: '#528bff',
+      selectionBackground: '#3e4451',
+      black: '#282c34',
+      red: '#e06c75',
+      green: '#98c379',
+      yellow: '#e5c07b',
+      blue: '#61afef',
+      magenta: '#c678dd',
+      cyan: '#56b6c2',
+      white: '#abb2bf',
+      brightBlack: '#5c6370',
+      brightRed: '#e06c75',
+      brightGreen: '#98c379',
+      brightYellow: '#e5c07b',
+      brightBlue: '#61afef',
+      brightMagenta: '#c678dd',
+      brightCyan: '#56b6c2',
+      brightWhite: '#ffffff'
+    }
+  },
+  {
+    name: 'Monokai',
+    theme: {
+      background: '#272822',
+      foreground: '#f8f8f2',
+      cursor: '#f8f8f0',
+      selectionBackground: '#49483e',
+      black: '#272822',
+      red: '#f92672',
+      green: '#a6e22e',
+      yellow: '#f4bf75',
+      blue: '#66d9ef',
+      magenta: '#ae81ff',
+      cyan: '#a1efe4',
+      white: '#f8f8f2',
+      brightBlack: '#75715e',
+      brightRed: '#f92672',
+      brightGreen: '#a6e22e',
+      brightYellow: '#f4bf75',
+      brightBlue: '#66d9ef',
+      brightMagenta: '#ae81ff',
+      brightCyan: '#a1efe4',
+      brightWhite: '#f9f8f5'
+    }
+  },
+  {
+    name: 'Gruvbox Dark',
+    theme: {
+      background: '#282828',
+      foreground: '#ebdbb2',
+      cursor: '#ebdbb2',
+      selectionBackground: '#504945',
+      black: '#282828',
+      red: '#cc241d',
+      green: '#98971a',
+      yellow: '#d79921',
+      blue: '#458588',
+      magenta: '#b16286',
+      cyan: '#689d6a',
+      white: '#a89984',
+      brightBlack: '#928374',
+      brightRed: '#fb4934',
+      brightGreen: '#b8bb26',
+      brightYellow: '#fabd2f',
+      brightBlue: '#83a598',
+      brightMagenta: '#d3869b',
+      brightCyan: '#8ec07c',
+      brightWhite: '#ebdbb2'
+    }
+  },
+  {
+    name: 'Tokyo Night',
+    theme: {
+      background: '#1a1b26',
+      foreground: '#c0caf5',
+      cursor: '#c0caf5',
+      selectionBackground: '#33467c',
+      black: '#15161e',
+      red: '#f7768e',
+      green: '#9ece6a',
+      yellow: '#e0af68',
+      blue: '#7aa2f7',
+      magenta: '#bb9af7',
+      cyan: '#7dcfff',
+      white: '#a9b1d6',
+      brightBlack: '#414868',
+      brightRed: '#f7768e',
+      brightGreen: '#9ece6a',
+      brightYellow: '#e0af68',
+      brightBlue: '#7aa2f7',
+      brightMagenta: '#bb9af7',
+      brightCyan: '#7dcfff',
+      brightWhite: '#c0caf5'
+    }
+  },
+  {
+    name: 'Catppuccin Mocha',
+    theme: {
+      background: '#1e1e2e',
+      foreground: '#cdd6f4',
+      cursor: '#f5e0dc',
+      selectionBackground: '#585b70',
+      black: '#45475a',
+      red: '#f38ba8',
+      green: '#a6e3a1',
+      yellow: '#f9e2af',
+      blue: '#89b4fa',
+      magenta: '#f5c2e7',
+      cyan: '#94e2d5',
+      white: '#bac2de',
+      brightBlack: '#585b70',
+      brightRed: '#f38ba8',
+      brightGreen: '#a6e3a1',
+      brightYellow: '#f9e2af',
+      brightBlue: '#89b4fa',
+      brightMagenta: '#f5c2e7',
+      brightCyan: '#94e2d5',
+      brightWhite: '#a6adc8'
+    }
+  }
+]
+
+export function getThemeNames(): string[] {
+  return builtinThemes.map((t) => t.name)
+}
+
+export function convertWindowsTerminalTheme(
+  input: WindowsTerminalTheme
+): ITheme {
+  const theme: ITheme = {}
+  if (input.background) theme.background = input.background
+  if (input.foreground) theme.foreground = input.foreground
+  if (input.cursorColor) theme.cursor = input.cursorColor
+  if (input.selectionBackground)
+    theme.selectionBackground = input.selectionBackground
+  if (input.black) theme.black = input.black
+  if (input.red) theme.red = input.red
+  if (input.green) theme.green = input.green
+  if (input.yellow) theme.yellow = input.yellow
+  if (input.blue) theme.blue = input.blue
+  if (input.purple) theme.magenta = input.purple
+  if (input.cyan) theme.cyan = input.cyan
+  if (input.white) theme.white = input.white
+  if (input.brightBlack) theme.brightBlack = input.brightBlack
+  if (input.brightRed) theme.brightRed = input.brightRed
+  if (input.brightGreen) theme.brightGreen = input.brightGreen
+  if (input.brightYellow) theme.brightYellow = input.brightYellow
+  if (input.brightBlue) theme.brightBlue = input.brightBlue
+  if (input.brightPurple) theme.brightMagenta = input.brightPurple
+  if (input.brightCyan) theme.brightCyan = input.brightCyan
+  if (input.brightWhite) theme.brightWhite = input.brightWhite
+  return theme
+}
+
+function isWindowsTerminalFormat(obj: Record<string, unknown>): boolean {
+  return 'purple' in obj || 'cursorColor' in obj || 'brightPurple' in obj
+}
+
+function isValidHexColor(value: unknown): boolean {
+  return typeof value === 'string' && HEX_COLOR_RE.test(value)
+}
+
+const THEME_COLOR_KEYS: string[] = [
+  'background',
+  'foreground',
+  'cursor',
+  'cursorAccent',
+  'selectionBackground',
+  'selectionForeground',
+  'selectionInactiveBackground',
+  'black',
+  'red',
+  'green',
+  'yellow',
+  'blue',
+  'magenta',
+  'cyan',
+  'white',
+  'brightBlack',
+  'brightRed',
+  'brightGreen',
+  'brightYellow',
+  'brightBlue',
+  'brightMagenta',
+  'brightCyan',
+  'brightWhite'
+]
+
+const WT_COLOR_KEYS: string[] = [
+  ...THEME_COLOR_KEYS,
+  'purple',
+  'brightPurple',
+  'cursorColor'
+]
+
+export function validateThemeJson(
+  jsonString: string
+): { theme: ITheme; name?: string } | { error: string } {
+  if (jsonString.length > 4096) {
+    return { error: 'Theme JSON exceeds 4KB size limit' }
+  }
+
+  let parsed: Record<string, unknown>
+  try {
+    parsed = JSON.parse(jsonString) as Record<string, unknown>
+  } catch {
+    return { error: 'Invalid JSON' }
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return { error: 'Theme must be a JSON object' }
+  }
+
+  const allowedKeys = isWindowsTerminalFormat(parsed)
+    ? WT_COLOR_KEYS
+    : THEME_COLOR_KEYS
+
+  for (const [key, value] of Object.entries(parsed)) {
+    if (
+      key !== 'name' &&
+      allowedKeys.includes(key) &&
+      !isValidHexColor(value)
+    ) {
+      return { error: `Invalid color value for "${key}": ${String(value)}` }
+    }
+  }
+
+  const name = typeof parsed['name'] === 'string' ? parsed['name'] : undefined
+
+  if (isWindowsTerminalFormat(parsed)) {
+    const result: { theme: ITheme; name?: string } = {
+      theme: convertWindowsTerminalTheme(
+        parsed as unknown as WindowsTerminalTheme
+      )
+    }
+    if (name !== undefined) result.name = name
+    return result
+  }
+
+  const theme: ITheme = {}
+  for (const key of THEME_COLOR_KEYS) {
+    const value = parsed[key]
+    if (isValidHexColor(value)) {
+      ;(theme as Record<string, string>)[key] = value as string
+    }
+  }
+  const result: { theme: ITheme; name?: string } = { theme }
+  if (name !== undefined) result.name = name
+  return result
+}
+
+export function resolveTheme(
+  themeName: string,
+  customTheme?: ITheme | null
+): ITheme {
+  if (themeName === 'custom' && customTheme) {
+    return customTheme
+  }
+  const found = builtinThemes.find((t) => t.name === themeName)
+  if (!found || themeName === 'Default') {
+    return {}
+  }
+  return found.theme
+}


### PR DESCRIPTION
## Summary

- Add a "Terminal Theme" expandable section to the Terminal Settings modal
- Bundle 10 popular built-in themes: Default, Dracula, Nord, Solarized Dark, Solarized Light, One Dark, Monokai, Gruvbox Dark, Tokyo Night, Catppuccin Mocha
- Support pasting custom theme JSON in both **Windows Terminal** format and **xterm.js ITheme** format (auto-detected and converted)
- Show color preview swatches when a theme is selected
- Persist theme selection in localStorage
- Sync container background color with the terminal theme to prevent visible borders

Closes billchurch/webssh2#496

Users can find hundreds of compatible themes at https://windowsterminalthemes.dev

## Test plan

- [x] Open Terminal Settings → expand "Terminal Theme" → select a built-in theme → verify terminal colors change
- [x] Select "Custom..." → paste any theme config from [windowsterminalthemes.dev](https://windowsterminalthemes.dev) → verify it validates and applies
- [x] Refresh page → verify theme persists from localStorage
- [x] Select "Default" → verify terminal returns to original colors
- [x] Verify no black borders visible with non-black background themes

<img width="897" height="646" alt="image" src="https://github.com/user-attachments/assets/520241a4-3d34-42d9-adfe-2da417195583" />

<img width="1164" height="491" alt="image" src="https://github.com/user-attachments/assets/482cc810-b851-409b-a920-eea4bca68873" />
