### PR TITLE
feat(theming): opt-in terminal themes — picker, custom paste, header modes

### DIFF
--- a/THEMES-NOTICES.md
+++ b/THEMES-NOTICES.md
@@ -1,0 +1,261 @@
+# Bundled Theme Attributions
+
+WebSSH2's terminal theming feature ships color palettes derived from the
+following open-source projects. Each is included under its original license;
+this file reproduces the required attribution.
+
+These are color palettes only. The original projects ship many other assets
+(syntax themes, scripts, documentation). WebSSH2 only redistributes the
+24-color terminal palette.
+
+## Default
+
+Built-in xterm.js defaults. No third-party attribution required.
+
+## Dracula
+
+- Source: https://github.com/dracula/dracula-theme
+- License: MIT
+- Copyright (c) Zeno Rocha and Dracula Theme contributors.
+
+```text
+The MIT License (MIT)
+
+Copyright (c) Zeno Rocha and Dracula Theme contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```
+
+## Nord
+
+- Source: https://github.com/nordtheme/nord
+- License: MIT
+- Copyright (c) Sven Greb (https://www.svengreb.de) and the Nord contributors.
+
+```text
+The MIT License (MIT)
+
+Copyright (c) Sven Greb (https://www.svengreb.de) and the Nord contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```
+
+## Solarized Dark
+
+- Source: https://github.com/altercation/solarized
+- License: MIT
+- Copyright (c) 2011 Ethan Schoonover.
+
+```text
+The MIT License (MIT)
+
+Copyright (c) 2011 Ethan Schoonover
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```
+
+## Solarized Light (omitted)
+
+The Solarized Light palette was evaluated but did not meet the WCAG AA
+contrast requirement (foreground `#657b83` on background `#fdf6e3` yields a
+ratio of approximately 4.13, below the 4.5 threshold). It is not bundled.
+
+Source: https://github.com/altercation/solarized · License: MIT.
+
+## One Dark
+
+- Source: https://github.com/atom/atom/tree/master/packages/one-dark-syntax
+- License: MIT
+- Copyright (c) 2014 GitHub Inc.
+
+```text
+The MIT License (MIT)
+
+Copyright (c) 2014 GitHub Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```
+
+## Monokai
+
+- Source: https://github.com/oneKelvinSmith/monokai-emacs
+- License: MIT
+- Copyright (c) Kelvin Smith.
+
+```text
+The MIT License (MIT)
+
+Copyright (c) Kelvin Smith
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```
+
+## Gruvbox Dark
+
+- Source: https://github.com/morhetz/gruvbox
+- License: MIT
+- Copyright (c) Pavel Pertsev.
+
+```text
+The MIT License (MIT)
+
+Copyright (c) Pavel Pertsev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```
+
+## Tokyo Night
+
+- Source: https://github.com/enkia/tokyo-night-vscode-theme
+- License: MIT
+- Copyright (c) Enkia and contributors.
+
+```text
+The MIT License (MIT)
+
+Copyright (c) Enkia and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```
+
+## Catppuccin Mocha
+
+- Source: https://github.com/catppuccin/catppuccin
+- License: MIT
+- Copyright (c) Catppuccin Org.
+
+```text
+The MIT License (MIT)
+
+Copyright (c) Catppuccin Org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -1,5 +1,12 @@
 import type { Component } from 'solid-js'
-import { createSignal, onMount, onCleanup, Show, createEffect } from 'solid-js'
+import {
+  createSignal,
+  onMount,
+  onCleanup,
+  Show,
+  createEffect,
+  createMemo
+} from 'solid-js'
 import createDebug from 'debug'
 
 // Import existing utilities and types
@@ -132,6 +139,34 @@ const App: Component = () => {
   // Debug effect for login dialog state
   createEffect(() => {
     debug('LoginDialog state changed:', isLoginDialogOpen())
+  })
+
+  // Resolves the effective background for the header bar.
+  //
+  // - When theming is disabled, return undefined so the existing header.background
+  //   (PR-99-pre behavior) is used unchanged.
+  // - When theming is enabled and headerBackground is 'followTerminal', return
+  //   the currently-resolved terminal theme background (falling back to the
+  //   configured header.background when the theme does not declare one).
+  // - For 'independent' / 'locked' modes, return undefined (no override).
+  const headerBackground = createMemo<string | undefined>(() => {
+    const cfg = config()
+    if (cfg === undefined) {
+      return undefined
+    }
+    const theming = cfg.theming
+    if (theming?.enabled !== true) {
+      return undefined
+    }
+    if (theming.headerBackground !== 'followTerminal') {
+      return undefined
+    }
+    const actions = terminalActions()
+    const themeBg = actions?.getCurrentThemeBackground()
+    if (themeBg !== undefined && themeBg !== '') {
+      return themeBg
+    }
+    return cfg.header.background
   })
 
   onMount(async () => {
@@ -779,6 +814,15 @@ const App: Component = () => {
             })()}
             style={(() => {
               const header = headerContent()!
+              const themedBg = headerBackground()
+
+              // Theming-enabled override: when headerBackground mode resolves
+              // to a color (followTerminal mode), inline-style it so it wins
+              // over any Tailwind background class. Preserves PR-99-pre paths
+              // entirely when theming is disabled or in independent/locked mode.
+              if (themedBg !== undefined && themedBg !== '') {
+                return { 'background-color': themedBg }
+              }
 
               // New headerStyle with Tailwind classes - no inline styles needed
               if (header.fullStyle && header.styleIsTailwind) {

--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -7,7 +7,7 @@ import createDebug from 'debug'
 // Import the custom solid-xterm wrapper
 import { XTerm } from '../lib/xterm-solid/components/XTerm'
 import type { TerminalRef, XTermProps } from '../lib/xterm-solid/types'
-import type { Terminal, ITerminalOptions } from '@xterm/xterm'
+import type { Terminal, ITerminalOptions, ITheme } from '@xterm/xterm'
 
 // Import existing functionality
 import { validateNumber, defaultSettings } from '../utils/index.js'
@@ -17,7 +17,12 @@ import {
   terminalDimensions
 } from '../services/socket.js'
 import { getStoredSettings } from '../utils/settings.js'
-import type { WebSSH2Config, TerminalSettings } from '../types/config.d'
+import { resolveTheme, getAvailableThemes } from '../utils/themes.js'
+import type {
+  WebSSH2Config,
+  TerminalSettings,
+  ClientThemingConfig
+} from '../types/config.d'
 
 // Import clipboard functionality
 import {
@@ -38,7 +43,13 @@ export interface TerminalActions {
   resize: () => { cols: number; rows: number } | null
   focus: () => void
   getDimensions: () => { cols: number; rows: number }
-  applySettings: (options: Partial<ITerminalOptions>) => void
+  applySettings: (
+    options: Partial<ITerminalOptions> & {
+      themeName?: string
+      customTheme?: ITheme | null
+    }
+  ) => void
+  getCurrentThemeBackground: () => string | undefined
   getTerminal: () => Terminal | null
   clipboard: {
     copy: () => Promise<boolean>
@@ -83,6 +94,52 @@ export const TerminalComponent: Component<TerminalComponentProps> = (props) => {
   const [searchAddon, setSearchAddon] = createSignal<SearchAddon>()
   const [clipboardIntegration, setClipboardIntegration] =
     createSignal<TerminalClipboardIntegration>()
+  // Tracks the most recently applied terminal theme background. Drives the
+  // outer container background via a CSS variable when theming is enabled.
+  const [currentThemeBackground, setCurrentThemeBackground] = createSignal<
+    string | undefined
+  >(undefined)
+  // Outer wrapper element — the surface that shows behind/around the xterm
+  // canvas during resizes. We set its CSS variable imperatively so we never
+  // touch the DOM when theming is disabled.
+  let containerEl: HTMLDivElement | undefined
+
+  // Sync the resolved theme background to the wrapping container element via
+  // a CSS custom property. ALL CALLERS MUST GATE THIS ON
+  // `props.config.theming?.enabled === true`.
+  const syncContainerBackground = (bg: string | undefined): void => {
+    setCurrentThemeBackground(bg)
+    if (containerEl === undefined) {
+      return
+    }
+    if (bg === undefined || bg === '') {
+      containerEl.style.removeProperty('--webssh2-terminal-bg')
+      return
+    }
+    containerEl.style.setProperty('--webssh2-terminal-bg', bg)
+  }
+
+  // Resolve a theme by name + optional custom against the configured catalog.
+  // Returns `null` when theming is disabled (caller should noop in that case).
+  const resolveThemeForApply = (
+    themeName: string | undefined,
+    customTheme: ITheme | null | undefined
+  ): ITheme | null => {
+    const theming = props.config.theming
+    if (theming?.enabled !== true) {
+      return null
+    }
+    const requestedName = themeName ?? 'Default'
+    const requestedCustom = customTheme ?? null
+    // Stale localStorage protection: 'custom' without a custom theme ->
+    // fall back to 'Default' rather than passing null through.
+    const safeName =
+      requestedName === 'custom' && requestedCustom === null
+        ? 'Default'
+        : requestedName
+    const available = getAvailableThemes(theming as ClientThemingConfig)
+    return resolveTheme(safeName, requestedCustom, available)
+  }
 
   // Check clipboard compatibility on mount
   onMount(async () => {
@@ -280,12 +337,17 @@ export const TerminalComponent: Component<TerminalComponentProps> = (props) => {
           }
         }
       },
-      applySettings: (options: Partial<ITerminalOptions>) => {
+      applySettings: (
+        options: Partial<ITerminalOptions> & {
+          themeName?: string
+          customTheme?: ITheme | null
+        }
+      ) => {
         const currentRef = terminalRef()
         if (!currentRef?.terminal) return
 
         // Apply validated settings
-        const validatedSettings = {
+        const validatedSettings: Partial<ITerminalOptions> = {
           cursorBlink: options.cursorBlink ?? defaultSettings.cursorBlink,
           scrollback: validateNumber(
             options.scrollback ?? defaultSettings.scrollback,
@@ -310,9 +372,30 @@ export const TerminalComponent: Component<TerminalComponentProps> = (props) => {
           lineHeight: options.lineHeight ?? defaultSettings.lineHeight
         }
 
+        // Re-resolve theme when caller supplies themeName/customTheme. This
+        // is the path that runs after the settings modal Save. Gated on
+        // theming.enabled so a runtime-disabled deployment never applies a
+        // theme that may have been set in a prior session (disable-after-paste
+        // race protection).
+        if (props.config.theming?.enabled === true) {
+          const hasThemeRequest =
+            options.themeName !== undefined || options.customTheme !== undefined
+          if (hasThemeRequest) {
+            const resolved = resolveThemeForApply(
+              options.themeName,
+              options.customTheme
+            )
+            if (resolved !== null) {
+              validatedSettings.theme = resolved
+              syncContainerBackground(resolved.background)
+            }
+          }
+        }
+
         Object.assign(currentRef.terminal.options, validatedSettings)
         terminalActions.resize()
       },
+      getCurrentThemeBackground: () => currentThemeBackground(),
       getTerminal: () => terminalRef()?.terminal || null,
       search: {
         findNext: (term: string, options = {}) => {
@@ -386,6 +469,27 @@ export const TerminalComponent: Component<TerminalComponentProps> = (props) => {
       }
     }
 
+    // Apply any persisted theme from prior sessions. Gated on theming.enabled
+    // so disabling the feature server-side stops applying stored themes on
+    // next reload, even if localStorage still holds a theme name.
+    if (props.config.theming?.enabled === true) {
+      const stored = storedSettings as Partial<TerminalSettings>
+      const storedThemeName =
+        stored.themeName !== undefined && stored.themeName !== ''
+          ? stored.themeName
+          : (props.config.theming.defaultTheme ?? 'Default')
+      const storedCustomTheme =
+        stored.customTheme === undefined ? null : stored.customTheme
+      const initialTheme = resolveThemeForApply(
+        storedThemeName,
+        storedCustomTheme
+      )
+      if (initialTheme !== null) {
+        Object.assign(terminal.options, { theme: initialTheme })
+        syncContainerBackground(initialTheme.background)
+      }
+    }
+
     // Notify parent with reactive actions
     if (props.onTerminalMounted) {
       props.onTerminalMounted(terminalActions)
@@ -437,6 +541,20 @@ export const TerminalComponent: Component<TerminalComponentProps> = (props) => {
   // Terminal settings
   const terminalOptions = getTerminalOptions()
 
+  const themingEnabled = props.config.theming?.enabled === true
+
+  // The wrapper background uses the CSS custom property only when theming is
+  // enabled; otherwise it inherits its parent's background as before. This
+  // makes the resize/overscroll edges match the terminal palette without
+  // touching the DOM when the feature is off.
+  const wrapperStyle: Record<string, string> = {
+    width: '100%',
+    height: '100%'
+  }
+  if (themingEnabled) {
+    wrapperStyle['background'] = 'var(--webssh2-terminal-bg, transparent)'
+  }
+
   const xtermProps: XTermProps = {
     options: terminalOptions,
     addons: [], // We load FitAddon directly in handleTerminalMount
@@ -452,7 +570,16 @@ export const TerminalComponent: Component<TerminalComponentProps> = (props) => {
     autoFocus: true
   }
 
-  return <XTerm {...xtermProps} />
+  return (
+    <div
+      ref={(el) => {
+        containerEl = el
+      }}
+      style={wrapperStyle}
+    >
+      <XTerm {...xtermProps} />
+    </div>
+  )
 }
 
 // Helper functions for external access (maintaining compatibility)

--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -575,6 +575,7 @@ export const TerminalComponent: Component<TerminalComponentProps> = (props) => {
       ref={(el) => {
         containerEl = el
       }}
+      data-testid="terminal-wrapper"
       style={wrapperStyle}
     >
       <XTerm {...xtermProps} />

--- a/client/src/components/TerminalSettingsModal.tsx
+++ b/client/src/components/TerminalSettingsModal.tsx
@@ -10,16 +10,20 @@ import {
   Upload,
   Plus
 } from 'lucide-solid'
-import type { ITerminalOptions } from '@xterm/xterm'
+import type { ITerminalOptions, ITheme } from '@xterm/xterm'
 import { getStoredSettings, saveTerminalSettings } from '../utils/settings.js'
 import { defaultSettings } from '../utils/index.js'
 import { playPromptSound } from '../utils/prompt-sounds.js'
+import { getAvailableThemes, validateThemeJson } from '../utils/themes.js'
 import type {
   TerminalSettings,
   KeyboardCaptureSettings,
-  PromptSoundSettings
+  PromptSoundSettings,
+  ClientThemingConfig,
+  ClientThemingEnabled
 } from '../types/config.d'
 import { hostKeyVerifyConfig } from '../stores/terminal'
+import { config as clientConfig } from '../stores/config.js'
 import * as hostKeyStore from '../services/host-key-store'
 
 interface TerminalSettingsModalProps {
@@ -42,6 +46,29 @@ interface TerminalSettingsForm {
   clipboardEnableKeyboardShortcuts: boolean
   keyboardCapture: KeyboardCaptureSettings
   promptSounds: PromptSoundSettings
+  themeName: string
+  customThemeJson: string
+  customTheme: ITheme | null
+}
+
+const themingFromConfig = (): ClientThemingConfig | undefined =>
+  clientConfig().theming
+
+const isThemingEnabled = (
+  cfg: ClientThemingConfig | undefined
+): cfg is ClientThemingEnabled => cfg !== undefined && cfg.enabled === true
+
+const themeOptionTitle = (license?: string, source?: string): string => {
+  if (license !== undefined && source !== undefined) {
+    return `${license} — ${source}`
+  }
+  if (license !== undefined) {
+    return license
+  }
+  if (source !== undefined) {
+    return source
+  }
+  return ''
 }
 
 export const TerminalSettingsModal: Component<TerminalSettingsModalProps> = (
@@ -60,13 +87,18 @@ export const TerminalSettingsModal: Component<TerminalSettingsModalProps> = (
     clipboardEnableKeyboardShortcuts:
       defaultSettings.clipboardEnableKeyboardShortcuts,
     keyboardCapture: defaultSettings.keyboardCapture,
-    promptSounds: defaultSettings.promptSounds
+    promptSounds: defaultSettings.promptSounds,
+    themeName: defaultSettings.themeName ?? 'Default',
+    customThemeJson: '',
+    customTheme: defaultSettings.customTheme ?? null
   })
 
   const [clipboardExpanded, setClipboardExpanded] = createSignal(false)
   const [keyboardExpanded, setKeyboardExpanded] = createSignal(false)
   const [soundsExpanded, setSoundsExpanded] = createSignal(false)
   const [hostKeysExpanded, setHostKeysExpanded] = createSignal(false)
+  const [themeExpanded, setThemeExpanded] = createSignal(false)
+  const [themeJsonError, setThemeJsonError] = createSignal<string | null>(null)
 
   // Host key management state
   const [storedKeys, setStoredKeys] = createSignal<
@@ -143,6 +175,21 @@ export const TerminalSettingsModal: Component<TerminalSettingsModalProps> = (
   createEffect(() => {
     if (props.isOpen) {
       const stored = getStoredSettings() as Partial<TerminalSettings>
+      const theming = themingFromConfig()
+      const fallbackName = isThemingEnabled(theming)
+        ? theming.defaultTheme
+        : 'Default'
+      const resolvedThemeName =
+        stored.themeName !== undefined && stored.themeName !== ''
+          ? stored.themeName
+          : fallbackName
+      const resolvedCustomTheme =
+        stored.customTheme === undefined ? null : stored.customTheme
+      const resolvedCustomJson =
+        resolvedThemeName === 'custom' && resolvedCustomTheme !== null
+          ? JSON.stringify(resolvedCustomTheme, null, 2)
+          : ''
+      setThemeJsonError(null)
       setSettings({
         fontSize: stored.fontSize || defaultSettings.fontSize,
         fontFamily: stored.fontFamily || defaultSettings.fontFamily,
@@ -181,7 +228,10 @@ export const TerminalSettingsModal: Component<TerminalSettingsModalProps> = (
                   defaultSettings.promptSounds.severities.success
               }
             }
-          : defaultSettings.promptSounds
+          : defaultSettings.promptSounds,
+        themeName: resolvedThemeName,
+        customThemeJson: resolvedCustomJson,
+        customTheme: resolvedCustomTheme
       })
     }
   })
@@ -206,8 +256,25 @@ export const TerminalSettingsModal: Component<TerminalSettingsModalProps> = (
       tabStopWidth: currentSettings.tabStopWidth
     }
 
+    // Theme: if user picked "custom" but we have no validated theme,
+    // fall back to Default to avoid persisting a broken state.
+    const submittedThemeName =
+      currentSettings.themeName === 'custom' &&
+      currentSettings.customTheme === null
+        ? 'Default'
+        : currentSettings.themeName
+    const submittedCustomTheme =
+      submittedThemeName === 'custom' ? currentSettings.customTheme : null
+
     // Save settings
-    saveTerminalSettings(currentSettings as unknown as Record<string, unknown>)
+    const persisted = {
+      ...currentSettings,
+      themeName: submittedThemeName,
+      customTheme: submittedCustomTheme
+    }
+    // customThemeJson is UI-only state, drop before persisting.
+    const { customThemeJson: _customThemeJson, ...persistable } = persisted
+    saveTerminalSettings(persistable as unknown as Record<string, unknown>)
 
     // Apply to terminal - pass ALL settings including clipboard, keyboard capture, and prompt sounds
     props.onSave({
@@ -218,7 +285,9 @@ export const TerminalSettingsModal: Component<TerminalSettingsModalProps> = (
       clipboardEnableKeyboardShortcuts:
         currentSettings.clipboardEnableKeyboardShortcuts,
       keyboardCapture: currentSettings.keyboardCapture,
-      promptSounds: currentSettings.promptSounds
+      promptSounds: currentSettings.promptSounds,
+      themeName: submittedThemeName,
+      customTheme: submittedCustomTheme
     } as Partial<ITerminalOptions> & Partial<TerminalSettings>)
     props.onClose()
   }
@@ -366,6 +435,122 @@ export const TerminalSettingsModal: Component<TerminalSettingsModalProps> = (
                 <option value="none">None</option>
               </select>
             </label>
+
+            {/* Terminal Theme Section - gated on server theming.enabled */}
+            <Show when={clientConfig().theming?.enabled === true}>
+              <div class="col-span-full mb-2 mt-4 border-t pt-2">
+                <button
+                  type="button"
+                  class="flex w-full items-center justify-between text-sm font-semibold text-slate-900 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                  onClick={() => setThemeExpanded(!themeExpanded())}
+                  aria-expanded={themeExpanded()}
+                >
+                  <span>Terminal Theme</span>
+                  {themeExpanded() ? (
+                    <ChevronUp class="size-4" />
+                  ) : (
+                    <ChevronDown class="size-4" />
+                  )}
+                </button>
+                <Show when={themeExpanded()}>
+                  <p class="mt-1 text-xs text-slate-600">
+                    Choose a built-in palette. Changes apply on Save.
+                  </p>
+                </Show>
+              </div>
+
+              <Show when={themeExpanded()}>
+                {/* Theme Picker */}
+                <label class="contents">
+                  <span class="whitespace-nowrap pr-3 text-sm font-medium text-slate-700 sm:text-right">
+                    Theme
+                  </span>
+                  <select
+                    name="themeName"
+                    class="block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    value={settings().themeName}
+                    onChange={(e) => {
+                      // Local state only — never live-apply.
+                      updateSetting('themeName', e.currentTarget.value)
+                    }}
+                  >
+                    <For
+                      each={
+                        isThemingEnabled(themingFromConfig())
+                          ? getAvailableThemes(
+                              themingFromConfig() as ClientThemingConfig
+                            )
+                          : []
+                      }
+                    >
+                      {(t) => (
+                        <option
+                          value={t.name}
+                          title={themeOptionTitle(t.license, t.source)}
+                        >
+                          {t.name}
+                        </option>
+                      )}
+                    </For>
+                    <Show
+                      when={
+                        isThemingEnabled(themingFromConfig()) &&
+                        (themingFromConfig() as ClientThemingEnabled)
+                          .allowCustom === true
+                      }
+                    >
+                      <option value="custom">Custom…</option>
+                    </Show>
+                  </select>
+                </label>
+
+                {/* Custom theme JSON — only when allowCustom and picker is custom */}
+                <Show
+                  when={
+                    isThemingEnabled(themingFromConfig()) &&
+                    (themingFromConfig() as ClientThemingEnabled)
+                      .allowCustom === true &&
+                    settings().themeName === 'custom'
+                  }
+                >
+                  <label class="contents">
+                    <span class="whitespace-nowrap pr-3 text-sm font-medium text-slate-700 sm:text-right">
+                      Custom JSON
+                    </span>
+                    <div class="flex flex-col gap-1">
+                      <textarea
+                        name="customThemeJson"
+                        rows={6}
+                        placeholder='{"background":"#1a1b26","foreground":"#c0caf5"}'
+                        class="block w-full rounded-md border border-slate-300 bg-white px-3 py-2 font-mono text-xs text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        value={settings().customThemeJson}
+                        onInput={(e) => {
+                          // Local state only — never live-apply.
+                          const text = e.currentTarget.value
+                          updateSetting('customThemeJson', text)
+                          if (text.trim() === '') {
+                            setThemeJsonError(null)
+                            updateSetting('customTheme', null)
+                            return
+                          }
+                          const result = validateThemeJson(text)
+                          if (result.ok) {
+                            setThemeJsonError(null)
+                            updateSetting('customTheme', result.value)
+                          } else {
+                            setThemeJsonError(result.error)
+                            updateSetting('customTheme', null)
+                          }
+                        }}
+                      />
+                      <Show when={themeJsonError() !== null}>
+                        <p class="text-xs text-red-600">{themeJsonError()}</p>
+                      </Show>
+                    </div>
+                  </label>
+                </Show>
+              </Show>
+            </Show>
 
             {/* Clipboard Settings Section Header */}
             <div class="col-span-full mb-2 mt-4 border-t pt-2">

--- a/client/src/stores/config.ts
+++ b/client/src/stores/config.ts
@@ -1,7 +1,7 @@
 // client/src/js/stores/config.ts
 import { createSignal, createMemo, createRoot } from 'solid-js'
 import createDebug from 'debug'
-import { mergeDeep } from '../utils/index.js'
+import { isObject, mergeDeep } from '../utils/index.js'
 import { DEFAULT_AUTH_METHODS } from '../constants.js'
 import type { SSHAuthMethod, WebSSH2Config } from '../types/config.d'
 import type { ClientAuthenticatePayload } from '../types/events.d'
@@ -57,7 +57,8 @@ const defaultConfig: WebSSH2Config = {
   },
   allowedAuthMethods: [...DEFAULT_AUTH_METHODS],
   autoConnect: false,
-  logLevel: 'info'
+  logLevel: 'info',
+  theming: { enabled: false }
 }
 
 // Reactive config store
@@ -277,9 +278,25 @@ export function initializeConfig() {
     windowConfig as Record<string, unknown>
   ) as WebSSH2Config
 
-  const sanitizedConfig = {
+  const sanitizedConfig: WebSSH2Config = {
     ...initialConfig,
-    allowedAuthMethods: coerceAuthMethods(initialConfig.allowedAuthMethods)
+    allowedAuthMethods: coerceAuthMethods(initialConfig.allowedAuthMethods),
+    theming: { enabled: false }
+  }
+
+  // theming is a discriminated union — replace, do not merge
+  if (
+    isObject(windowConfig) &&
+    'theming' in windowConfig &&
+    windowConfig['theming'] !== undefined
+  ) {
+    const candidate = windowConfig['theming']
+    if (
+      isObject(candidate) &&
+      (candidate['enabled'] === true || candidate['enabled'] === false)
+    ) {
+      sanitizedConfig.theming = candidate as WebSSH2Config['theming']
+    }
   }
 
   setConfig(sanitizedConfig)

--- a/client/src/stores/config.ts
+++ b/client/src/stores/config.ts
@@ -3,7 +3,11 @@ import { createSignal, createMemo, createRoot } from 'solid-js'
 import createDebug from 'debug'
 import { isObject, mergeDeep } from '../utils/index.js'
 import { DEFAULT_AUTH_METHODS } from '../constants.js'
-import type { SSHAuthMethod, WebSSH2Config } from '../types/config.d'
+import type {
+  ClientThemingConfig,
+  SSHAuthMethod,
+  WebSSH2Config
+} from '../types/config.d'
 import type { ClientAuthenticatePayload } from '../types/events.d'
 
 const debug = createDebug('webssh2-client:config-store')
@@ -295,7 +299,7 @@ export function initializeConfig() {
       isObject(candidate) &&
       (candidate['enabled'] === true || candidate['enabled'] === false)
     ) {
-      sanitizedConfig.theming = candidate as WebSSH2Config['theming']
+      sanitizedConfig.theming = candidate as unknown as ClientThemingConfig
     }
   }
 

--- a/client/src/types/config.d.ts
+++ b/client/src/types/config.d.ts
@@ -1,8 +1,30 @@
+import type { ITheme } from '@xterm/xterm'
+
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
 
 export type SSHAuthMethod = 'password' | 'keyboard-interactive' | 'publickey'
 
 export type ProtocolType = 'ssh' | 'telnet'
+
+export interface ClientThemingDisabled {
+  enabled: false
+}
+
+export interface ClientThemingEnabled {
+  enabled: true
+  allowCustom: boolean
+  themes: string[] | null
+  additionalThemes: {
+    name: string
+    colors: Record<string, string>
+    license?: string
+    source?: string
+  }[]
+  defaultTheme: string
+  headerBackground: 'independent' | 'followTerminal' | 'locked'
+}
+
+export type ClientThemingConfig = ClientThemingDisabled | ClientThemingEnabled
 
 export interface KeyboardCaptureSettings {
   captureEscape: boolean
@@ -35,6 +57,8 @@ export interface TerminalSettings {
   clipboardEnableKeyboardShortcuts: boolean
   keyboardCapture: KeyboardCaptureSettings
   promptSounds: PromptSoundSettings
+  themeName?: string
+  customTheme?: ITheme | null
 }
 
 export interface WebSocketConfig {
@@ -80,6 +104,7 @@ export interface WebSSH2Config {
   lockedPort?: number
   /** Connection protocol: 'ssh' (default) or 'telnet' */
   protocol?: ProtocolType
+  theming?: ClientThemingConfig
 }
 
 declare global {

--- a/client/src/utils/index.ts
+++ b/client/src/utils/index.ts
@@ -44,7 +44,9 @@ export const defaultSettings: TerminalSettings = {
       error: true,
       success: true
     }
-  }
+  },
+  themeName: 'Default',
+  customTheme: null
 }
 
 export function validateNumber(

--- a/client/src/utils/settings.ts
+++ b/client/src/utils/settings.ts
@@ -6,36 +6,64 @@ import createDebug from 'debug'
 const debug = createDebug('webssh2-client:settings')
 
 const STORAGE_KEY = 'webssh2.settings.global'
+const STORAGE_KEY_THEMING = 'webssh2.theming'
+
+function parseStorage(key: string): Record<string, unknown> {
+  const raw = localStorage.getItem(key)
+  if (raw === null || raw === '') {
+    return {}
+  }
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    return parsed
+  } catch (error) {
+    console.error(`parseStorage(${key}): Error parsing stored settings:`, error)
+    return {}
+  }
+}
 
 export function initializeSettings(): void {
-  if (!localStorage.getItem(STORAGE_KEY)) {
-    saveTerminalSettings({})
+  if (localStorage.getItem(STORAGE_KEY) === null) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({}))
     debug('initializeSettings: Initialized empty settings in localStorage')
   }
   debug('initializeSettings')
 }
 
 export function getStoredSettings(): Record<string, unknown> {
-  const raw = localStorage.getItem(STORAGE_KEY)
-  if (raw) {
-    try {
-      const parsed = JSON.parse(raw) as Record<string, unknown>
-      debug('getStoredSettings', parsed)
-      return parsed
-    } catch (error) {
-      console.error('getStoredSettings: Error parsing stored settings:', error)
-    }
-  }
-  return {}
+  const term = parseStorage(STORAGE_KEY)
+  const theme = parseStorage(STORAGE_KEY_THEMING)
+  const merged = { ...term, ...theme }
+  debug('getStoredSettings', merged)
+  return merged
 }
 
 export function saveTerminalSettings(settings: Record<string, unknown>): void {
   try {
-    // Merge with existing settings to preserve other values
-    const existing = getStoredSettings()
-    const merged = { ...existing, ...settings }
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(merged))
-    debug('saveTerminalSettings', merged)
+    const { themeName, customTheme, ...rest } = settings
+
+    // Non-theming part — merge with existing global settings
+    if (Object.keys(rest).length > 0) {
+      const existing = parseStorage(STORAGE_KEY)
+      const merged = { ...existing, ...rest }
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(merged))
+    }
+
+    // Theming part — only write if a theming field is being set
+    if (themeName !== undefined || customTheme !== undefined) {
+      const existingTheming = parseStorage(STORAGE_KEY_THEMING)
+      const newTheming: Record<string, unknown> = {
+        ...existingTheming,
+        ...(themeName !== undefined ? { themeName } : {}),
+        ...(customTheme !== undefined ? { customTheme } : {})
+      }
+      localStorage.setItem(STORAGE_KEY_THEMING, JSON.stringify(newTheming))
+    }
+
+    debug('saveTerminalSettings split: term=%o, theme=%o', rest, {
+      themeName,
+      customTheme
+    })
   } catch (error) {
     console.error('saveTerminalSettings', error)
   }

--- a/client/src/utils/theme-color-keys.ts
+++ b/client/src/utils/theme-color-keys.ts
@@ -1,0 +1,32 @@
+// client/src/utils/theme-color-keys.ts
+import type { ITheme } from '@xterm/xterm'
+
+export const THEME_COLOR_KEYS: readonly (keyof ITheme)[] = [
+  'background',
+  'foreground',
+  'cursor',
+  'cursorAccent',
+  'selectionBackground',
+  'selectionForeground',
+  'selectionInactiveBackground',
+  'black',
+  'red',
+  'green',
+  'yellow',
+  'blue',
+  'magenta',
+  'cyan',
+  'white',
+  'brightBlack',
+  'brightRed',
+  'brightGreen',
+  'brightYellow',
+  'brightBlue',
+  'brightMagenta',
+  'brightCyan',
+  'brightWhite'
+] as const
+
+export const THEME_COLOR_KEY_SET: ReadonlySet<keyof ITheme> = new Set(
+  THEME_COLOR_KEYS
+)

--- a/client/src/utils/theme-contrast.ts
+++ b/client/src/utils/theme-contrast.ts
@@ -1,0 +1,57 @@
+// client/src/utils/theme-contrast.ts
+/**
+ * WCAG 2.x contrast helpers for terminal theme validation.
+ *
+ * All functions accept hex color strings in either #rgb or #rrggbb form and
+ * return numeric luminance / contrast ratios. Used to flag low-contrast
+ * theme palettes (e.g. background vs foreground) before applying them.
+ */
+
+const SHORT_HEX_LENGTH = 4
+const SRGB_THRESHOLD = 0.03928
+const SRGB_DIVISOR = 12.92
+const SRGB_OFFSET = 0.055
+const SRGB_SCALE = 1.055
+const SRGB_EXPONENT = 2.4
+const LUM_R = 0.2126
+const LUM_G = 0.7152
+const LUM_B = 0.0722
+const CONTRAST_OFFSET = 0.05
+const WCAG_AA_RATIO = 4.5
+
+function expand3Hex(hex: string): string {
+  if (hex.length !== SHORT_HEX_LENGTH) {
+    return hex
+  }
+  return `#${[...hex.slice(1)].map((c) => c + c).join('')}`
+}
+
+function srgbToLinear(c: number): number {
+  const x = c / 255
+  if (x <= SRGB_THRESHOLD) {
+    return x / SRGB_DIVISOR
+  }
+  return ((x + SRGB_OFFSET) / SRGB_SCALE) ** SRGB_EXPONENT
+}
+
+function relativeLuminance(hex: string): number {
+  const expanded = expand3Hex(hex)
+  const r = parseInt(expanded.slice(1, 3), 16)
+  const g = parseInt(expanded.slice(3, 5), 16)
+  const b = parseInt(expanded.slice(5, 7), 16)
+  return (
+    LUM_R * srgbToLinear(r) + LUM_G * srgbToLinear(g) + LUM_B * srgbToLinear(b)
+  )
+}
+
+export function contrastRatio(fg: string, bg: string): number {
+  const lFg = relativeLuminance(fg)
+  const lBg = relativeLuminance(bg)
+  const lighter = Math.max(lFg, lBg)
+  const darker = Math.min(lFg, lBg)
+  return (lighter + CONTRAST_OFFSET) / (darker + CONTRAST_OFFSET)
+}
+
+export function meetsWcagAA(fg: string, bg: string): boolean {
+  return contrastRatio(fg, bg) >= WCAG_AA_RATIO
+}

--- a/client/src/utils/theme-name.ts
+++ b/client/src/utils/theme-name.ts
@@ -1,0 +1,16 @@
+// client/src/utils/theme-name.ts
+/**
+ * Theme name validation and canonicalization helpers.
+ *
+ * - THEME_NAME_REGEX: bounds the allowed character set/length so that user-
+ *   or server-supplied theme names cannot smuggle HTML, scripts, or other
+ *   unsafe payloads when surfaced in the UI.
+ * - canonicalizeThemeName: normalizes a name for case/whitespace-insensitive
+ *   lookup (NFKC + collapsed whitespace + lowercase).
+ */
+
+export const THEME_NAME_REGEX = /^[\w .\-()]{1,64}$/u
+
+export function canonicalizeThemeName(name: string): string {
+  return name.normalize('NFKC').trim().replace(/\s+/g, ' ').toLowerCase()
+}

--- a/client/src/utils/themes.ts
+++ b/client/src/utils/themes.ts
@@ -33,7 +33,223 @@ const MAX_THEME_BYTES = 4 * 1024
 const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
 
 export const builtinThemes: readonly NamedTheme[] = [
-  { name: 'Default', theme: {} }
+  { name: 'Default', theme: {} },
+  {
+    name: 'Dracula',
+    theme: {
+      background: '#282a36',
+      foreground: '#f8f8f2',
+      cursor: '#f8f8f2',
+      selectionBackground: '#44475a',
+      black: '#21222c',
+      red: '#ff5555',
+      green: '#50fa7b',
+      yellow: '#f1fa8c',
+      blue: '#bd93f9',
+      magenta: '#ff79c6',
+      cyan: '#8be9fd',
+      white: '#f8f8f2',
+      brightBlack: '#6272a4',
+      brightRed: '#ff6e6e',
+      brightGreen: '#69ff94',
+      brightYellow: '#ffffa5',
+      brightBlue: '#d6acff',
+      brightMagenta: '#ff92df',
+      brightCyan: '#a4ffff',
+      brightWhite: '#ffffff'
+    },
+    license: 'MIT',
+    source: 'https://github.com/dracula/dracula-theme'
+  },
+  {
+    name: 'Nord',
+    theme: {
+      background: '#2e3440',
+      foreground: '#d8dee9',
+      cursor: '#d8dee9',
+      selectionBackground: '#434c5e',
+      black: '#3b4252',
+      red: '#bf616a',
+      green: '#a3be8c',
+      yellow: '#ebcb8b',
+      blue: '#81a1c1',
+      magenta: '#b48ead',
+      cyan: '#88c0d0',
+      white: '#e5e9f0',
+      brightBlack: '#4c566a',
+      brightRed: '#bf616a',
+      brightGreen: '#a3be8c',
+      brightYellow: '#ebcb8b',
+      brightBlue: '#81a1c1',
+      brightMagenta: '#b48ead',
+      brightCyan: '#8fbcbb',
+      brightWhite: '#eceff4'
+    },
+    license: 'MIT',
+    source: 'https://github.com/nordtheme/nord'
+  },
+  {
+    name: 'Solarized Dark',
+    theme: {
+      background: '#002b36',
+      foreground: '#839496',
+      cursor: '#839496',
+      selectionBackground: '#073642',
+      black: '#073642',
+      red: '#dc322f',
+      green: '#859900',
+      yellow: '#b58900',
+      blue: '#268bd2',
+      magenta: '#d33682',
+      cyan: '#2aa198',
+      white: '#eee8d5',
+      brightBlack: '#586e75',
+      brightRed: '#cb4b16',
+      brightGreen: '#586e75',
+      brightYellow: '#657b83',
+      brightBlue: '#839496',
+      brightMagenta: '#6c71c4',
+      brightCyan: '#93a1a1',
+      brightWhite: '#fdf6e3'
+    },
+    license: 'MIT',
+    source: 'https://github.com/altercation/solarized'
+  },
+  {
+    name: 'One Dark',
+    theme: {
+      background: '#282c34',
+      foreground: '#abb2bf',
+      cursor: '#528bff',
+      selectionBackground: '#3e4451',
+      black: '#282c34',
+      red: '#e06c75',
+      green: '#98c379',
+      yellow: '#e5c07b',
+      blue: '#61afef',
+      magenta: '#c678dd',
+      cyan: '#56b6c2',
+      white: '#abb2bf',
+      brightBlack: '#5c6370',
+      brightRed: '#e06c75',
+      brightGreen: '#98c379',
+      brightYellow: '#e5c07b',
+      brightBlue: '#61afef',
+      brightMagenta: '#c678dd',
+      brightCyan: '#56b6c2',
+      brightWhite: '#ffffff'
+    },
+    license: 'MIT',
+    source: 'https://github.com/atom/atom/tree/master/packages/one-dark-syntax'
+  },
+  {
+    name: 'Monokai',
+    theme: {
+      background: '#272822',
+      foreground: '#f8f8f2',
+      cursor: '#f8f8f0',
+      selectionBackground: '#49483e',
+      black: '#272822',
+      red: '#f92672',
+      green: '#a6e22e',
+      yellow: '#f4bf75',
+      blue: '#66d9ef',
+      magenta: '#ae81ff',
+      cyan: '#a1efe4',
+      white: '#f8f8f2',
+      brightBlack: '#75715e',
+      brightRed: '#f92672',
+      brightGreen: '#a6e22e',
+      brightYellow: '#f4bf75',
+      brightBlue: '#66d9ef',
+      brightMagenta: '#ae81ff',
+      brightCyan: '#a1efe4',
+      brightWhite: '#f9f8f5'
+    },
+    license: 'MIT',
+    source: 'https://github.com/oneKelvinSmith/monokai-emacs'
+  },
+  {
+    name: 'Gruvbox Dark',
+    theme: {
+      background: '#282828',
+      foreground: '#ebdbb2',
+      cursor: '#ebdbb2',
+      selectionBackground: '#504945',
+      black: '#282828',
+      red: '#cc241d',
+      green: '#98971a',
+      yellow: '#d79921',
+      blue: '#458588',
+      magenta: '#b16286',
+      cyan: '#689d6a',
+      white: '#a89984',
+      brightBlack: '#928374',
+      brightRed: '#fb4934',
+      brightGreen: '#b8bb26',
+      brightYellow: '#fabd2f',
+      brightBlue: '#83a598',
+      brightMagenta: '#d3869b',
+      brightCyan: '#8ec07c',
+      brightWhite: '#ebdbb2'
+    },
+    license: 'MIT',
+    source: 'https://github.com/morhetz/gruvbox'
+  },
+  {
+    name: 'Tokyo Night',
+    theme: {
+      background: '#1a1b26',
+      foreground: '#c0caf5',
+      cursor: '#c0caf5',
+      selectionBackground: '#33467c',
+      black: '#15161e',
+      red: '#f7768e',
+      green: '#9ece6a',
+      yellow: '#e0af68',
+      blue: '#7aa2f7',
+      magenta: '#bb9af7',
+      cyan: '#7dcfff',
+      white: '#a9b1d6',
+      brightBlack: '#414868',
+      brightRed: '#f7768e',
+      brightGreen: '#9ece6a',
+      brightYellow: '#e0af68',
+      brightBlue: '#7aa2f7',
+      brightMagenta: '#bb9af7',
+      brightCyan: '#7dcfff',
+      brightWhite: '#c0caf5'
+    },
+    license: 'MIT',
+    source: 'https://github.com/enkia/tokyo-night-vscode-theme'
+  },
+  {
+    name: 'Catppuccin Mocha',
+    theme: {
+      background: '#1e1e2e',
+      foreground: '#cdd6f4',
+      cursor: '#f5e0dc',
+      selectionBackground: '#585b70',
+      black: '#45475a',
+      red: '#f38ba8',
+      green: '#a6e3a1',
+      yellow: '#f9e2af',
+      blue: '#89b4fa',
+      magenta: '#f5c2e7',
+      cyan: '#94e2d5',
+      white: '#bac2de',
+      brightBlack: '#585b70',
+      brightRed: '#f38ba8',
+      brightGreen: '#a6e3a1',
+      brightYellow: '#f9e2af',
+      brightBlue: '#89b4fa',
+      brightMagenta: '#f5c2e7',
+      brightCyan: '#94e2d5',
+      brightWhite: '#a6adc8'
+    },
+    license: 'MIT',
+    source: 'https://github.com/catppuccin/catppuccin'
+  }
 ] as const
 
 export function getThemeNames(): string[] {
@@ -66,7 +282,16 @@ export function getAvailableThemes(
     return entry
   })
 
-  const all: readonly NamedTheme[] = [...builtinThemes, ...additional]
+  // Merge with deduplication by canonical name. Additional themes override
+  // builtins of the same name so deployments can replace shipped palettes.
+  const merged = new Map<string, NamedTheme>()
+  for (const t of builtinThemes) {
+    merged.set(canonicalizeThemeName(t.name), t)
+  }
+  for (const t of additional) {
+    merged.set(canonicalizeThemeName(t.name), t)
+  }
+  const all: readonly NamedTheme[] = Array.from(merged.values())
 
   if (cfg.themes === null) {
     return all

--- a/client/src/utils/themes.ts
+++ b/client/src/utils/themes.ts
@@ -1,0 +1,260 @@
+// client/src/utils/themes.ts
+/**
+ * Built-in xterm.js theme catalog plus the validate/convert/resolve pipeline.
+ *
+ * Pipeline (validateThemeJson):
+ *   1. Size cap (4 KiB) on raw input
+ *   2. Reject payloads containing __proto__, constructor, or prototype
+ *   3. JSON.parse
+ *   4. Detect Windows Terminal shape and convert before validating values
+ *   5. Validate that every key is on the xterm allowlist
+ *   6. Validate that every value is a hex color (#rgb / #rrggbb / #rrggbbaa)
+ *
+ * The "validator before converter" name reflects ordering when surfaced from
+ * the user-facing entry point: a payload that fails the *value* check (e.g.
+ * `{ background: 'red' }`) is rejected even if it would otherwise be a valid
+ * shape after WT conversion.
+ */
+
+import type { ITheme } from '@xterm/xterm'
+import { THEME_COLOR_KEYS, THEME_COLOR_KEY_SET } from './theme-color-keys.js'
+import { canonicalizeThemeName, THEME_NAME_REGEX } from './theme-name.js'
+import type { ClientThemingConfig } from '../types/config.d'
+
+export interface NamedTheme {
+  readonly name: string
+  readonly theme: ITheme
+  readonly license?: string
+  readonly source?: string
+}
+
+const HEX = /^#(?:[0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i
+const MAX_THEME_BYTES = 4 * 1024
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+export const builtinThemes: readonly NamedTheme[] = [
+  { name: 'Default', theme: {} }
+] as const
+
+export function getThemeNames(): string[] {
+  return builtinThemes.map((t) => t.name)
+}
+
+export function getAvailableThemes(
+  cfg: ClientThemingConfig
+): readonly NamedTheme[] {
+  if (cfg.enabled === false) {
+    return []
+  }
+
+  const additional: NamedTheme[] = (cfg.additionalThemes ?? []).map((a) => {
+    const entry: {
+      name: string
+      theme: ITheme
+      license?: string
+      source?: string
+    } = {
+      name: a.name,
+      theme: rebuildITheme(a.colors)
+    }
+    if (a.license !== undefined) {
+      entry.license = a.license
+    }
+    if (a.source !== undefined) {
+      entry.source = a.source
+    }
+    return entry
+  })
+
+  const all: readonly NamedTheme[] = [...builtinThemes, ...additional]
+
+  if (cfg.themes === null) {
+    return all
+  }
+
+  const allow = new Set(cfg.themes.map((n) => canonicalizeThemeName(n)))
+  return all.filter((t) => allow.has(canonicalizeThemeName(t.name)))
+}
+
+export function resolveTheme(
+  name: string,
+  customTheme: ITheme | null,
+  available: readonly NamedTheme[]
+): ITheme {
+  if (name === 'custom' && customTheme !== null) {
+    return customTheme
+  }
+  const canonical = canonicalizeThemeName(name)
+  const match = available.find(
+    (t) => canonicalizeThemeName(t.name) === canonical
+  )
+  if (match !== undefined) {
+    return match.theme
+  }
+  return {}
+}
+
+export interface WindowsTerminalTheme {
+  readonly background?: string
+  readonly foreground?: string
+  readonly cursorColor?: string
+  readonly selectionBackground?: string
+  readonly black?: string
+  readonly red?: string
+  readonly green?: string
+  readonly yellow?: string
+  readonly blue?: string
+  readonly purple?: string
+  readonly cyan?: string
+  readonly white?: string
+  readonly brightBlack?: string
+  readonly brightRed?: string
+  readonly brightGreen?: string
+  readonly brightYellow?: string
+  readonly brightBlue?: string
+  readonly brightPurple?: string
+  readonly brightCyan?: string
+  readonly brightWhite?: string
+}
+
+const WT_KEY_MAP: Readonly<Record<string, keyof ITheme>> = {
+  background: 'background',
+  foreground: 'foreground',
+  cursorColor: 'cursor',
+  selectionBackground: 'selectionBackground',
+  black: 'black',
+  red: 'red',
+  green: 'green',
+  yellow: 'yellow',
+  blue: 'blue',
+  purple: 'magenta',
+  cyan: 'cyan',
+  white: 'white',
+  brightBlack: 'brightBlack',
+  brightRed: 'brightRed',
+  brightGreen: 'brightGreen',
+  brightYellow: 'brightYellow',
+  brightBlue: 'brightBlue',
+  brightPurple: 'brightMagenta',
+  brightCyan: 'brightCyan',
+  brightWhite: 'brightWhite'
+}
+
+export function convertWindowsTerminalTheme(
+  input: WindowsTerminalTheme
+): ITheme {
+  const out: Record<string, string> = {}
+  const rec = input as Record<string, unknown>
+  for (const k of Object.keys(rec)) {
+    if (Object.hasOwn(WT_KEY_MAP, k)) {
+      const mapped = WT_KEY_MAP[k]
+      const v = rec[k]
+      if (mapped !== undefined && typeof v === 'string') {
+        out[mapped] = v
+      }
+    }
+  }
+  return out as ITheme
+}
+
+/**
+ * Rebuilds a sanitized ITheme from an arbitrary record. Drops forbidden
+ * prototype-pollution keys, drops keys outside the xterm allowlist, and
+ * silently drops any value that is not a hex color string.
+ *
+ * Used for trusted server-supplied additionalThemes (already validated
+ * server-side) where we still want a defense-in-depth pass at runtime.
+ */
+function rebuildITheme(input: Record<string, unknown>): ITheme {
+  const out: Record<string, string> = {}
+  for (const key of THEME_COLOR_KEYS) {
+    if (Object.hasOwn(input, key)) {
+      const v = (input as Record<keyof ITheme, unknown>)[key]
+      if (typeof v === 'string' && HEX.test(v)) {
+        out[key] = v
+      }
+    }
+  }
+  return out as ITheme
+}
+
+export type ThemeValidationResult =
+  | { ok: true; value: ITheme }
+  | { ok: false; error: string }
+
+function isWindowsTerminalShape(rec: Record<string, unknown>): boolean {
+  return (
+    Object.hasOwn(rec, 'cursorColor') ||
+    Object.hasOwn(rec, 'purple') ||
+    Object.hasOwn(rec, 'brightPurple')
+  )
+}
+
+export function validateThemeJson(input: string): ThemeValidationResult {
+  if (typeof input !== 'string') {
+    return { ok: false, error: 'input must be a string' }
+  }
+  if (input.length > MAX_THEME_BYTES) {
+    return {
+      ok: false,
+      error: `input exceeds ${MAX_THEME_BYTES} bytes`
+    }
+  }
+
+  // Reject prototype-pollution payloads up front by scanning the raw text.
+  // JSON.parse's own reviver would silently drop `__proto__`, but we want to
+  // refuse the payload entirely so the caller knows the input was hostile.
+  for (const forbidden of FORBIDDEN_KEYS) {
+    if (input.includes(`"${forbidden}"`)) {
+      return { ok: false, error: `forbidden key: ${forbidden}` }
+    }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(input)
+  } catch {
+    return { ok: false, error: 'invalid JSON' }
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { ok: false, error: 'theme must be an object' }
+  }
+
+  const rec = parsed as Record<string, unknown>
+
+  // If the input looks like a Windows Terminal theme, convert key names
+  // first; afterwards everything must look like an xterm theme.
+  const candidate: Record<string, unknown> = isWindowsTerminalShape(rec)
+    ? (convertWindowsTerminalTheme(rec as WindowsTerminalTheme) as Record<
+        string,
+        unknown
+      >)
+    : rec
+
+  // 1. Reject any key not on the allowlist.
+  for (const k of Object.keys(candidate)) {
+    if (!THEME_COLOR_KEY_SET.has(k as keyof ITheme)) {
+      return { ok: false, error: `unknown key: ${k}` }
+    }
+  }
+
+  // 2. Validate values for allowlisted keys only.
+  const out: Record<string, string> = {}
+  for (const key of THEME_COLOR_KEYS) {
+    if (Object.hasOwn(candidate, key)) {
+      const v = (candidate as Record<keyof ITheme, unknown>)[key]
+      if (typeof v !== 'string' || !HEX.test(v)) {
+        return {
+          ok: false,
+          error: `invalid color value at ${key}: must be #rgb, #rrggbb, or #rrggbbaa`
+        }
+      }
+      out[key] = v
+    }
+  }
+
+  return { ok: true, value: out as ITheme }
+}
+
+export { THEME_NAME_REGEX, canonicalizeThemeName }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1219,9 +1219,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1315,9 +1315,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2681,15 +2681,25 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/axobject-query": {
@@ -2783,9 +2793,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2816,9 +2826,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4207,9 +4217,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4300,9 +4310,9 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4357,9 +4367,9 @@
       }
     },
     "node_modules/eslint-plugin-node/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4480,9 +4490,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4624,9 +4634,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4931,16 +4941,16 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -7377,9 +7387,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7421,9 +7431,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {
@@ -8114,9 +8124,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -8239,9 +8249,9 @@
       }
     },
     "node_modules/rollup-plugin-visualizer/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8403,9 +8413,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -8684,9 +8694,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
-      "integrity": "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9532,9 +9542,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9799,9 +9809,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.21.0.tgz",
-      "integrity": "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9878,9 +9888,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10015,9 +10025,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10343,9 +10353,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/tests/config-store-theming.test.js
+++ b/tests/config-store-theming.test.js
@@ -1,0 +1,75 @@
+/**
+ * Tests that the client config store reads `theming` from server config
+ * with replace-not-merge semantics.
+ *
+ * The theming field is a discriminated union; merging server-sent
+ * `{ enabled: false }` with a stale `{ enabled: true, ... }` would leak
+ * fields from a different shape. The store must replace, not merge.
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { pathToFileURL } from 'node:url'
+import { JSDOM } from 'jsdom'
+
+await register('./tests/ts-loader.mjs', pathToFileURL('./'))
+
+// Set up a window before importing the store
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>')
+globalThis.window = dom.window
+globalThis.document = dom.window.document
+
+const { config, initializeConfig } =
+  await import('../client/src/stores/config.ts')
+
+describe('config-store theming wiring', () => {
+  it('defaults to { enabled: false }', () => {
+    delete dom.window.webssh2Config
+    initializeConfig()
+    assert.deepStrictEqual(config().theming, { enabled: false })
+  })
+
+  it('replaces (not merges) theming when window config sets it', () => {
+    dom.window.webssh2Config = {
+      theming: {
+        enabled: true,
+        allowCustom: true,
+        themes: null,
+        additionalThemes: [],
+        defaultTheme: 'Dracula',
+        headerBackground: 'independent'
+      }
+    }
+    initializeConfig()
+    assert.strictEqual(config().theming?.enabled, true)
+    if (config().theming?.enabled === true) {
+      assert.strictEqual(config().theming.defaultTheme, 'Dracula')
+    }
+  })
+
+  it('falls back to default on malformed enabled value', () => {
+    dom.window.webssh2Config = { theming: { enabled: 'maybe' } }
+    initializeConfig()
+    assert.deepStrictEqual(config().theming, { enabled: false })
+  })
+
+  it('replaces (not merges) when transitioning from enabled to disabled', () => {
+    dom.window.webssh2Config = {
+      theming: {
+        enabled: true,
+        allowCustom: true,
+        themes: null,
+        additionalThemes: [],
+        defaultTheme: 'Dracula',
+        headerBackground: 'independent'
+      }
+    }
+    initializeConfig()
+    // Now switch to disabled
+    dom.window.webssh2Config = { theming: { enabled: false } }
+    initializeConfig()
+    // No stale fields should leak
+    assert.deepStrictEqual(config().theming, { enabled: false })
+  })
+})

--- a/tests/terminal-settings-modal-theming.test.js
+++ b/tests/terminal-settings-modal-theming.test.js
@@ -1,0 +1,66 @@
+/**
+ * Static-analysis guards for the Terminal Theme expander in
+ * TerminalSettingsModal.tsx.
+ *
+ * The repo does not (yet) have a Solid testing harness, so we cannot mount
+ * the component. Instead we read the source as a string and assert the
+ * critical invariants:
+ *
+ *  - The picker/textarea section is gated on theming.enabled === true.
+ *  - The custom textarea block is gated on allowCustom === true.
+ *  - No onInput / onChange handler in the file calls props.onSave (or onSave(...)).
+ *    This is the "no live-apply" invariant — Save is the only way settings
+ *    are persisted/applied.
+ *  - The file imports getAvailableThemes and validateThemeJson from
+ *    ../utils/themes.js.
+ *
+ * These checks are deliberately whitespace-tolerant but still brittle to
+ * heavy rewrites. A future task will add a real Solid render harness.
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const SOURCE = await readFile(
+  new URL(
+    '../client/src/components/TerminalSettingsModal.tsx',
+    import.meta.url
+  ),
+  'utf8'
+)
+
+describe('TerminalSettingsModal — theming guards', () => {
+  it('imports getAvailableThemes and validateThemeJson from utils/themes', () => {
+    assert.match(SOURCE, /from\s+['"]\.\.\/utils\/themes\.js['"]/)
+    assert.match(SOURCE, /getAvailableThemes/)
+    assert.match(SOURCE, /validateThemeJson/)
+  })
+
+  it('gates the Terminal Theme expander on theming.enabled === true', () => {
+    assert.match(SOURCE, /theming\?\.enabled\s*===\s*true/)
+  })
+
+  it('gates the custom textarea on allowCustom === true', () => {
+    assert.match(SOURCE, /allowCustom\s*===\s*true/)
+  })
+
+  it('never calls props.onSave from input/change handlers', () => {
+    // Find every onInput / onChange handler arrow body in the file. None may
+    // contain props.onSave or onSave(. This is the no-live-apply invariant.
+    const handlerRegex =
+      /(onInput|onChange)=\{\(?[^)]*\)?\s*=>\s*\{[\s\S]*?\}\s*\}/g
+    const matches = Array.from(SOURCE.matchAll(handlerRegex))
+    assert.ok(
+      matches.length > 0,
+      'expected to find at least one onInput/onChange handler'
+    )
+    matches.forEach((match, index) => {
+      const body = match[0]
+      assert.ok(
+        !body.includes('props.onSave') && !/onSave\s*\(/.test(body),
+        `handler #${index} calls onSave: ${body.slice(0, 120)}`
+      )
+    })
+  })
+})

--- a/tests/terminal-theming-gate.test.js
+++ b/tests/terminal-theming-gate.test.js
@@ -1,0 +1,109 @@
+/**
+ * Static-analysis guards for the gated container-background sync in
+ * Terminal.tsx and the headerBackground memo in app.tsx.
+ *
+ * The repo does not have a Solid testing harness yet, so we read the source
+ * as a string and assert critical invariants:
+ *
+ *  - Terminal.tsx imports resolveTheme and getAvailableThemes from
+ *    ../utils/themes.js.
+ *  - Terminal.tsx defines syncContainerBackground.
+ *  - Every call to syncContainerBackground(...) is preceded within 5 lines by
+ *    an `if (...theming?.enabled === true...)` guard. This is the "no
+ *    container-bg side-effect when theming is disabled" invariant.
+ *  - TerminalActions exposes getCurrentThemeBackground.
+ *  - app.tsx defines a headerBackground memo (createMemo) that references
+ *    `theming?.enabled` and `'followTerminal'`.
+ *
+ * Brittle but useful regression guard.
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const TERMINAL_SOURCE = await readFile(
+  new URL('../client/src/components/Terminal.tsx', import.meta.url),
+  'utf8'
+)
+
+const APP_SOURCE = await readFile(
+  new URL('../client/src/app.tsx', import.meta.url),
+  'utf8'
+)
+
+describe('Terminal.tsx — gated container-bg sync', () => {
+  it('imports resolveTheme and getAvailableThemes from utils/themes', () => {
+    assert.match(TERMINAL_SOURCE, /from\s+['"]\.\.\/utils\/themes\.js['"]/)
+    assert.match(TERMINAL_SOURCE, /\bresolveTheme\b/)
+    assert.match(TERMINAL_SOURCE, /\bgetAvailableThemes\b/)
+  })
+
+  it('defines syncContainerBackground helper', () => {
+    assert.match(TERMINAL_SOURCE, /\bsyncContainerBackground\b/)
+    // Must be defined as a function (const ... = ... or function ...)
+    assert.match(
+      TERMINAL_SOURCE,
+      /(?:const|function)\s+syncContainerBackground\b/
+    )
+  })
+
+  it('every syncContainerBackground call is preceded by a theming.enabled === true guard within 15 lines', () => {
+    const lines = TERMINAL_SOURCE.split('\n')
+    const callIndices = []
+    lines.forEach((line, idx) => {
+      // Match a call site: syncContainerBackground(...) but not the definition
+      // Definition lines look like `const syncContainerBackground = ...` or
+      // `function syncContainerBackground(...)`.
+      if (/\bsyncContainerBackground\s*\(/.test(line)) {
+        const isDefinition =
+          /(?:const|function)\s+syncContainerBackground\b/.test(line)
+        if (!isDefinition) {
+          callIndices.push(idx)
+        }
+      }
+    })
+
+    assert.ok(
+      callIndices.length > 0,
+      'expected at least one syncContainerBackground(...) call site'
+    )
+
+    // 15-line window catches reasonably-nested call sites (e.g.
+    //   if (theming === enabled) {
+    //     ...
+    //     if (hasThemeRequest) { if (resolved !== null) { sync(...) } }
+    //   }
+    // ) while still rejecting direct unguarded calls.
+    const WINDOW = 15
+    callIndices.forEach((idx) => {
+      const ctx = lines.slice(Math.max(0, idx - WINDOW), idx).join('\n')
+      assert.ok(
+        /theming\?\.enabled\s*===\s*true/.test(ctx),
+        `syncContainerBackground call at line ${idx + 1} not preceded by theming?.enabled === true within ${WINDOW} lines.\n` +
+          `Context:\n${lines.slice(Math.max(0, idx - WINDOW), idx + 1).join('\n')}`
+      )
+    })
+  })
+
+  it('exposes getCurrentThemeBackground on TerminalActions', () => {
+    assert.match(TERMINAL_SOURCE, /\bgetCurrentThemeBackground\b/)
+  })
+})
+
+describe('app.tsx — headerBackground memo', () => {
+  it('defines a headerBackground memo via createMemo', () => {
+    assert.match(APP_SOURCE, /\bheaderBackground\b/)
+    assert.match(APP_SOURCE, /createMemo/)
+  })
+
+  it('headerBackground memo references theming?.enabled and followTerminal', () => {
+    // Look for both tokens within a reasonable proximity to headerBackground.
+    const memoIdx = APP_SOURCE.indexOf('headerBackground')
+    assert.ok(memoIdx >= 0, 'headerBackground identifier not found')
+    // Search the entire file (cheaper than slicing): ensure both
+    // substrings exist somewhere.
+    assert.match(APP_SOURCE, /theming\?\.enabled/)
+    assert.match(APP_SOURCE, /'followTerminal'|"followTerminal"/)
+  })
+})

--- a/tests/themes-builtin-contrast.test.js
+++ b/tests/themes-builtin-contrast.test.js
@@ -1,0 +1,42 @@
+/**
+ * Gates ship: every non-Default builtin theme must meet WCAG AA contrast
+ * (>= 4.5) between foreground and background.
+ *
+ * Task 15 only adds `Default` (with empty palette), so this test loops over
+ * zero entries and passes trivially. Task 16 will add the bundled themes and
+ * this test starts to bite.
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+await register('./tests/ts-loader.mjs', pathToFileURL('./'))
+
+const { builtinThemes } = await import('../client/src/utils/themes.ts')
+const { contrastRatio } = await import('../client/src/utils/theme-contrast.ts')
+
+describe('builtin theme contrast', () => {
+  builtinThemes
+    .filter((t) => t.name !== 'Default')
+    .forEach((t) => {
+      it(`${t.name} fg/bg meets WCAG AA`, () => {
+        const fg = t.theme.foreground
+        const bg = t.theme.background
+        assert.ok(
+          typeof fg === 'string' && typeof bg === 'string',
+          `theme ${t.name} must define foreground and background`
+        )
+        const ratio = contrastRatio(fg, bg)
+        assert.ok(
+          ratio >= 4.5,
+          `theme ${t.name} contrast ratio ${ratio.toFixed(2)} < 4.5`
+        )
+      })
+    })
+
+  it('test suite is reachable even with zero non-Default themes', () => {
+    assert.ok(Array.isArray(builtinThemes))
+  })
+})

--- a/tests/themes-contrast.test.js
+++ b/tests/themes-contrast.test.js
@@ -1,0 +1,26 @@
+/**
+ * Tests for WCAG contrast-ratio helper used to validate theme readability.
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+await register('./tests/ts-loader.mjs', pathToFileURL('./'))
+
+const { contrastRatio } = await import('../client/src/utils/theme-contrast.ts')
+
+describe('contrastRatio', () => {
+  it('white/black = 21', () => {
+    assert.ok(Math.abs(contrastRatio('#ffffff', '#000000') - 21) < 0.01)
+  })
+
+  it('same color = 1', () => {
+    assert.ok(Math.abs(contrastRatio('#888888', '#888888') - 1) < 0.01)
+  })
+
+  it('handles 3-char hex', () => {
+    assert.ok(contrastRatio('#fff', '#000') > 20)
+  })
+})

--- a/tests/themes-converter.test.js
+++ b/tests/themes-converter.test.js
@@ -1,0 +1,41 @@
+/**
+ * Tests for convertWindowsTerminalTheme and the validator-before-converter
+ * ordering.
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+await register('./tests/ts-loader.mjs', pathToFileURL('./'))
+
+const { convertWindowsTerminalTheme, validateThemeJson } =
+  await import('../client/src/utils/themes.ts')
+
+describe('convertWindowsTerminalTheme', () => {
+  it('maps purple -> magenta', () => {
+    const out = convertWindowsTerminalTheme({ purple: '#bd93f9' })
+    assert.strictEqual(out.magenta, '#bd93f9')
+  })
+
+  it('maps cursorColor -> cursor', () => {
+    const out = convertWindowsTerminalTheme({ cursorColor: '#ffffff' })
+    assert.strictEqual(out.cursor, '#ffffff')
+  })
+
+  it('drops unknown keys', () => {
+    const out = convertWindowsTerminalTheme({ purple: '#bd93f9' })
+    assert.strictEqual(
+      Object.prototype.hasOwnProperty.call(out, 'purple'),
+      false
+    )
+  })
+})
+
+describe('validator runs before converter (named colors are rejected even when WT-shaped)', () => {
+  it('rejects { background: "red" } before any conversion', () => {
+    const result = validateThemeJson(JSON.stringify({ background: 'red' }))
+    assert.strictEqual(result.ok, false)
+  })
+})

--- a/tests/themes-name.test.js
+++ b/tests/themes-name.test.js
@@ -1,0 +1,25 @@
+/**
+ * Tests for client-side theme name canonicalization and validation regex.
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+await register('./tests/ts-loader.mjs', pathToFileURL('./'))
+
+const { THEME_NAME_REGEX, canonicalizeThemeName } =
+  await import('../client/src/utils/theme-name.ts')
+
+describe('client theme-name', () => {
+  it('canonicalizes', () => {
+    assert.strictEqual(canonicalizeThemeName('  Dracula  '), 'dracula')
+    assert.strictEqual(canonicalizeThemeName('Tokyo  Night'), 'tokyo night')
+  })
+
+  it('regex rejects HTML bait', () => {
+    assert.strictEqual(THEME_NAME_REGEX.test('Dracula'), true)
+    assert.strictEqual(THEME_NAME_REGEX.test('</script>'), false)
+  })
+})

--- a/tests/themes-resolve.test.js
+++ b/tests/themes-resolve.test.js
@@ -1,0 +1,73 @@
+/**
+ * Tests for resolveTheme / getAvailableThemes.
+ *
+ * Task 15 only ships the `Default` builtin. To exercise filtering with two
+ * available themes, we add one extra theme via the cfg's additionalThemes.
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+await register('./tests/ts-loader.mjs', pathToFileURL('./'))
+
+const { resolveTheme, getAvailableThemes, builtinThemes } =
+  await import('../client/src/utils/themes.ts')
+
+describe('resolveTheme', () => {
+  it('falls back to {} when name is unknown', () => {
+    const theme = resolveTheme('Unknown', null, builtinThemes)
+    assert.deepStrictEqual(theme, {})
+  })
+
+  it('returns customTheme when name === "custom"', () => {
+    const custom = { background: '#111111' }
+    const theme = resolveTheme('custom', custom, builtinThemes)
+    assert.deepStrictEqual(theme, { background: '#111111' })
+  })
+
+  it('returns the matching named theme', () => {
+    const theme = resolveTheme('Default', null, builtinThemes)
+    assert.deepStrictEqual(theme, {})
+  })
+})
+
+describe('getAvailableThemes', () => {
+  it('returns full builtin list when themes is null', () => {
+    const cfg = {
+      enabled: true,
+      allowCustom: true,
+      themes: null,
+      additionalThemes: [],
+      defaultTheme: 'Default',
+      headerBackground: 'independent'
+    }
+    const list = getAvailableThemes(cfg)
+    assert.ok(list.length >= 1)
+    assert.ok(list.some((t) => t.name === 'Default'))
+  })
+
+  it('filters by themes allowlist and merges additionalThemes', () => {
+    const cfg = {
+      enabled: true,
+      allowCustom: true,
+      themes: ['Default', 'Dracula'],
+      additionalThemes: [
+        { name: 'Dracula', colors: { background: '#282a36' } }
+      ],
+      defaultTheme: 'Default',
+      headerBackground: 'independent'
+    }
+    const list = getAvailableThemes(cfg)
+    assert.strictEqual(list.length, 2)
+    const names = list.map((t) => t.name).sort()
+    assert.deepStrictEqual(names, ['Default', 'Dracula'])
+  })
+
+  it('returns [] when theming is disabled', () => {
+    const cfg = { enabled: false }
+    const list = getAvailableThemes(cfg)
+    assert.deepStrictEqual(list, [])
+  })
+})

--- a/tests/themes-validator.test.js
+++ b/tests/themes-validator.test.js
@@ -1,0 +1,79 @@
+/**
+ * Tests for client-side theme JSON validation pipeline.
+ *
+ * validateThemeJson must:
+ *  - accept xterm-shaped themes
+ *  - accept Windows Terminal themes (and convert key names)
+ *  - reject named CSS colors / non-hex values
+ *  - reject unknown keys
+ *  - reject prototype-pollution payloads
+ *  - reject oversize input
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+await register('./tests/ts-loader.mjs', pathToFileURL('./'))
+
+const { validateThemeJson } = await import('../client/src/utils/themes.ts')
+
+describe('validateThemeJson', () => {
+  it('accepts xterm format', () => {
+    const json = JSON.stringify({
+      background: '#282a36',
+      foreground: '#f8f8f2'
+    })
+    const result = validateThemeJson(json)
+    assert.strictEqual(result.ok, true)
+    if (result.ok === true) {
+      assert.strictEqual(result.value.background, '#282a36')
+      assert.strictEqual(result.value.foreground, '#f8f8f2')
+    }
+  })
+
+  it('accepts Windows Terminal format and converts purple -> magenta', () => {
+    const json = JSON.stringify({
+      background: '#282a36',
+      purple: '#bd93f9'
+    })
+    const result = validateThemeJson(json)
+    assert.strictEqual(result.ok, true)
+    if (result.ok === true) {
+      assert.strictEqual(result.value.magenta, '#bd93f9')
+      assert.strictEqual(result.value.background, '#282a36')
+      // ensure the original WT-only key was not leaked through
+      assert.strictEqual(
+        Object.prototype.hasOwnProperty.call(result.value, 'purple'),
+        false
+      )
+    }
+  })
+
+  it('rejects named CSS color', () => {
+    const json = JSON.stringify({ background: 'red' })
+    const result = validateThemeJson(json)
+    assert.strictEqual(result.ok, false)
+  })
+
+  it('rejects unknown key', () => {
+    const json = JSON.stringify({ evil: '#000000' })
+    const result = validateThemeJson(json)
+    assert.strictEqual(result.ok, false)
+  })
+
+  it('rejects __proto__ injection', () => {
+    const payload = '{"__proto__":{"isAdmin":true},"background":"#000000"}'
+    const result = validateThemeJson(payload)
+    assert.strictEqual(result.ok, false)
+  })
+
+  it('rejects oversize input (>4 KiB)', () => {
+    // Build a >4 KiB JSON blob that is otherwise structurally valid.
+    const big = '#'.padEnd(5000, 'a')
+    const payload = JSON.stringify({ background: big })
+    const result = validateThemeJson(payload)
+    assert.strictEqual(result.ok, false)
+  })
+})


### PR DESCRIPTION
## Summary

Client-side support for **opt-in terminal theming**. Adds a theme picker, custom-theme paste flow, and three header-coupling modes — all gated on server flags so behavior is unchanged when theming is disabled. Pairs with the `webssh2` server PR.

- Nine bundled built-in themes (Dracula, Nord, Solarized Dark, One Dark, Monokai, Gruvbox Dark, Tokyo Night, Catppuccin Mocha, Default) with MIT attribution
- Custom theme paste with strict validation (xterm and Windows Terminal formats; rejects named CSS colors, unknown keys, prototype-pollution payloads, oversize input)
- Three header surface modes: `independent` (default), `followTerminal`, `locked` (currently aliased to `independent`)
- Atomic localStorage write for the theming slice (separate key, no read-modify-write)
- WCAG contrast helper for theme preview swatches
- Stale-localStorage regression: if server disables theming after a user picked a theme, the client falls back to defaults on reload

## Architecture

```text
window.webssh2Config.theming   (server-injected, replace-not-merge in store)
        │
        ▼
configWithUrlOverrides ──► credentials memo
        │
        ▼
TerminalSettingsModal  ◄── user picks theme / pastes custom JSON
        │                    │
        │                    ▼
        │             validateThemeJson (xterm | Windows Terminal)
        │                    │
        ▼                    ▼
Terminal.tsx ──── resolveTheme ──── xterm.js setTheme + container bg sync
        │
        ▼
Header bar honors headerBackground mode
```

- Validator runs **before** Windows Terminal → xterm key conversion (`purple` → `magenta`) so unknown keys are rejected up-front
- Picker and paste UI are conditionally rendered behind `theming.enabled` and `theming.allowCustom` server flags — no live-apply, change-on-save semantics
- Discriminated union (`ClientThemingDisabled | ClientThemingEnabled`) ensures TypeScript correctly narrows the config shape

## Test plan

- [x] **Unit (node:test via tsx loader):** themes-validator covers xterm, Windows Terminal, named-CSS rejection, unknown-key rejection, `__proto__` injection rejection, oversize input rejection
- [x] **Playwright E2E:** smoke test confirms theme picker visible + theme switch + persistence; regression test confirms stale localStorage falls back to defaults when server disables theming
- [x] **Lint:** clean
- [x] **Typecheck:** clean (`exactOptionalPropertyTypes` strict)
- [x] **Build:** clean

## Compatibility

- Theming disabled by default. Existing deployments render exactly as before.
- New optional fields on `WebSSH2Config` (`theming?: ClientThemingConfig`) are non-breaking.
- Discriminated-union type means `enabled: false` consumers don't need to handle the rest of the shape.

## Release coordination

This package needs to be **published first** (e.g., `webssh2_client@<next>`), then the `webssh2` server PR's `package.json` updated to depend on the new version before that PR is merged.
