### PR TITLE
feat!: adopt content-hashed output filenames for immutable caching

### DIFF
--- a/DOCS/develop/BUILD.md
+++ b/DOCS/develop/BUILD.md
@@ -46,7 +46,7 @@ Ensure your SSH or GPG key is set up for git commit signing and added to your gi
    npm run build
    ```
 
-   This runs Vite in production mode and outputs to `client/public/` (e.g., `webssh2.bundle.js`, `webssh2.css`, `client.htm`).
+   This runs Vite in production mode and outputs to `client/public/` (e.g., `webssh2-<hash>.js`, `webssh2-<hash>.css`, `xterm-<hash>.css`, `client.htm`).
 
 5. Type-check (recommended):
 

--- a/DOCS/develop/DEVELOPMENT.md
+++ b/DOCS/develop/DEVELOPMENT.md
@@ -149,7 +149,7 @@ npm run build:server # Node entrypoints to JS
 
 Artifacts:
 
-- Client: `client/public/{webssh2.bundle.js, webssh2.css, client.htm}`
+- Client: `client/public/{webssh2-<hash>.js, webssh2-<hash>.css, xterm-<hash>.css, client.htm}`
 - Node: root `index.js`, `client/index.js` (compiled from TypeScript)
 
 ## Type Checking and Linting

--- a/DOCS/develop/MOBILE-TODO.md
+++ b/DOCS/develop/MOBILE-TODO.md
@@ -40,7 +40,7 @@ Goal: Provide an optional, compact keypad for modifier/special keys.
   - `<meta name="apple-mobile-web-app-title" content="WebSSH2">`
   - Apple touch icons (180x180).
 - Service Worker (later milestone):
-  - Online‑first; cache static assets (`webssh2.bundle.js`, `webssh2.css`, `client.htm`, icons).
+  - Online‑first; cache static assets (`webssh2-<hash>.js`, `webssh2-<hash>.css`, `client.htm`, icons).
   - No offline for terminal sessions; show friendly offline page for the shell UI only.
   - Consider Workbox (vite-plugin-pwa) with explicit CSP.
 - Install prompts:

--- a/client/src/vite.config.js
+++ b/client/src/vite.config.js
@@ -118,27 +118,32 @@ export default defineConfig(({ mode }) => {
           main: 'index.html'
         },
         output: {
+          hashCharacters: 'hex',
           entryFileNames: (chunkInfo) => {
             return chunkInfo.name === 'main'
-              ? 'webssh2.bundle.js'
-              : '[name].bundle.js'
+              ? 'webssh2-[hash].js'
+              : '[name]-[hash].js'
           },
           chunkFileNames: '[name]-[hash].js',
           assetFileNames: (assetInfo) => {
+            // favicon.ico keeps a stable name (server contract; see #109)
+            if (assetInfo.name === 'favicon.ico') {
+              return 'favicon.ico'
+            }
             if (
               assetInfo.name === 'style.css' ||
               assetInfo.name === 'index.css'
             ) {
-              return 'webssh2.css'
+              return 'webssh2-[hash].css'
             }
             if (
               assetInfo.name &&
               assetInfo.name.startsWith('main') &&
               assetInfo.name.endsWith('.css')
             ) {
-              return 'webssh2.css'
+              return 'webssh2-[hash].css'
             }
-            return '[name][extname]'
+            return '[name]-[hash][extname]'
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build": "cd client/src && vite build --mode production",
     "builddev": "cd client/src && vite build --mode development",
     "build:link": "npm run build && npm link",
-    "check-version": "grep -o 'Version.*alpha.*[0-9]' client/public/webssh2.bundle.js || echo 'Version not found in bundle'",
+    "check-version": "grep -o 'Version.*alpha.*[0-9]' client/public/webssh2-*.js || echo 'Version not found in bundle'",
     "dev": "cd client/src && vite --mode development",
     "watch": "cd client/src && vite --mode development",
     "analyze": "cd client/src && vite build --mode production && vite-bundle-visualizer",

--- a/tests/build-output.test.js
+++ b/tests/build-output.test.js
@@ -1,0 +1,77 @@
+/**
+ * Verifies the production build emits content-hashed filenames compatible
+ * with the webssh2 gateway's immutable-cache pattern (-\w{8,}\.(js|css)),
+ * and that client.htm references the emitted names exactly.
+ *
+ * Skips when no build output is present (run `npm run build` first).
+ * CI builds before testing, so these assertions always run there.
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const publicDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../client/public'
+)
+const hasBuild = fs.existsSync(path.join(publicDir, 'client.htm'))
+
+// Matches the webssh2 gateway's immutable-cache filename pattern.
+// hashCharacters: 'hex' guarantees [0-9a-f]; \w{8,} is the server contract.
+const HASHED_PATTERN = /^[A-Za-z0-9_.]+-[0-9a-f]{8,}\.(js|css)$/
+
+describe('production build output', { skip: !hasBuild && 'no build output' }, () => {
+  const files = hasBuild ? fs.readdirSync(publicDir) : []
+  const jsFiles = files.filter((f) => f.endsWith('.js'))
+  const cssFiles = files.filter((f) => f.endsWith('.css'))
+
+  it('keeps stable names for client.htm and favicon.ico', () => {
+    assert.ok(files.includes('client.htm'))
+    assert.ok(files.includes('favicon.ico'))
+  })
+
+  it('emits no legacy stable-named bundles', () => {
+    assert.ok(!files.includes('webssh2.bundle.js'))
+    assert.ok(!files.includes('webssh2.css'))
+    assert.ok(!files.includes('xterm.css'))
+  })
+
+  it('emits only gateway-immutable-compatible hashed js/css names', () => {
+    for (const f of [...jsFiles, ...cssFiles]) {
+      assert.match(f, HASHED_PATTERN, `${f} would miss immutable caching`)
+    }
+  })
+
+  it('emits one hashed entry bundle and two distinct hashed stylesheets', () => {
+    assert.strictEqual(
+      jsFiles.filter((f) => f.startsWith('webssh2-')).length,
+      1
+    )
+    assert.strictEqual(
+      cssFiles.filter((f) => f.startsWith('webssh2-')).length,
+      1
+    )
+    assert.strictEqual(
+      cssFiles.filter((f) => f.startsWith('xterm-')).length,
+      1
+    )
+  })
+
+  it('client.htm references the emitted hashed entry and stylesheet', () => {
+    const html = fs.readFileSync(path.join(publicDir, 'client.htm'), 'utf-8')
+    const entry = jsFiles.find((f) => f.startsWith('webssh2-'))
+    const css = cssFiles.find((f) => f.startsWith('webssh2-'))
+    assert.ok(html.includes(`./${entry}`), `client.htm missing ${entry}`)
+    assert.ok(html.includes(`./${css}`), `client.htm missing ${css}`)
+  })
+
+  it('entry bundle references the hashed xterm stylesheet for dynamic import', () => {
+    const entry = jsFiles.find((f) => f.startsWith('webssh2-'))
+    const xtermCss = cssFiles.find((f) => f.startsWith('xterm-'))
+    const code = fs.readFileSync(path.join(publicDir, entry), 'utf-8')
+    assert.ok(code.includes(xtermCss), `bundle missing ref to ${xtermCss}`)
+  })
+})

--- a/tests/build-output.test.js
+++ b/tests/build-output.test.js
@@ -23,55 +23,59 @@ const hasBuild = fs.existsSync(path.join(publicDir, 'client.htm'))
 // hashCharacters: 'hex' guarantees [0-9a-f]; \w{8,} is the server contract.
 const HASHED_PATTERN = /^[A-Za-z0-9_.]+-[0-9a-f]{8,}\.(js|css)$/
 
-describe('production build output', { skip: !hasBuild && 'no build output' }, () => {
-  const files = hasBuild ? fs.readdirSync(publicDir) : []
-  const jsFiles = files.filter((f) => f.endsWith('.js'))
-  const cssFiles = files.filter((f) => f.endsWith('.css'))
+describe(
+  'production build output',
+  { skip: !hasBuild && 'no build output' },
+  () => {
+    const files = hasBuild ? fs.readdirSync(publicDir) : []
+    const jsFiles = files.filter((f) => f.endsWith('.js'))
+    const cssFiles = files.filter((f) => f.endsWith('.css'))
 
-  it('keeps stable names for client.htm and favicon.ico', () => {
-    assert.ok(files.includes('client.htm'))
-    assert.ok(files.includes('favicon.ico'))
-  })
+    it('keeps stable names for client.htm and favicon.ico', () => {
+      assert.ok(files.includes('client.htm'))
+      assert.ok(files.includes('favicon.ico'))
+    })
 
-  it('emits no legacy stable-named bundles', () => {
-    assert.ok(!files.includes('webssh2.bundle.js'))
-    assert.ok(!files.includes('webssh2.css'))
-    assert.ok(!files.includes('xterm.css'))
-  })
+    it('emits no legacy stable-named bundles', () => {
+      assert.ok(!files.includes('webssh2.bundle.js'))
+      assert.ok(!files.includes('webssh2.css'))
+      assert.ok(!files.includes('xterm.css'))
+    })
 
-  it('emits only gateway-immutable-compatible hashed js/css names', () => {
-    for (const f of [...jsFiles, ...cssFiles]) {
-      assert.match(f, HASHED_PATTERN, `${f} would miss immutable caching`)
-    }
-  })
+    it('emits only gateway-immutable-compatible hashed js/css names', () => {
+      ;[...jsFiles, ...cssFiles].forEach((f) => {
+        assert.match(f, HASHED_PATTERN, `${f} would miss immutable caching`)
+      })
+    })
 
-  it('emits one hashed entry bundle and two distinct hashed stylesheets', () => {
-    assert.strictEqual(
-      jsFiles.filter((f) => f.startsWith('webssh2-')).length,
-      1
-    )
-    assert.strictEqual(
-      cssFiles.filter((f) => f.startsWith('webssh2-')).length,
-      1
-    )
-    assert.strictEqual(
-      cssFiles.filter((f) => f.startsWith('xterm-')).length,
-      1
-    )
-  })
+    it('emits one hashed entry bundle and two distinct hashed stylesheets', () => {
+      assert.strictEqual(
+        jsFiles.filter((f) => f.startsWith('webssh2-')).length,
+        1
+      )
+      assert.strictEqual(
+        cssFiles.filter((f) => f.startsWith('webssh2-')).length,
+        1
+      )
+      assert.strictEqual(
+        cssFiles.filter((f) => f.startsWith('xterm-')).length,
+        1
+      )
+    })
 
-  it('client.htm references the emitted hashed entry and stylesheet', () => {
-    const html = fs.readFileSync(path.join(publicDir, 'client.htm'), 'utf-8')
-    const entry = jsFiles.find((f) => f.startsWith('webssh2-'))
-    const css = cssFiles.find((f) => f.startsWith('webssh2-'))
-    assert.ok(html.includes(`./${entry}`), `client.htm missing ${entry}`)
-    assert.ok(html.includes(`./${css}`), `client.htm missing ${css}`)
-  })
+    it('client.htm references the emitted hashed entry and stylesheet', () => {
+      const html = fs.readFileSync(path.join(publicDir, 'client.htm'), 'utf-8')
+      const entry = jsFiles.find((f) => f.startsWith('webssh2-'))
+      const css = cssFiles.find((f) => f.startsWith('webssh2-'))
+      assert.ok(html.includes(`./${entry}`), `client.htm missing ${entry}`)
+      assert.ok(html.includes(`./${css}`), `client.htm missing ${css}`)
+    })
 
-  it('entry bundle references the hashed xterm stylesheet for dynamic import', () => {
-    const entry = jsFiles.find((f) => f.startsWith('webssh2-'))
-    const xtermCss = cssFiles.find((f) => f.startsWith('xterm-'))
-    const code = fs.readFileSync(path.join(publicDir, entry), 'utf-8')
-    assert.ok(code.includes(xtermCss), `bundle missing ref to ${xtermCss}`)
-  })
-})
+    it('entry bundle references the hashed xterm stylesheet for dynamic import', () => {
+      const entry = jsFiles.find((f) => f.startsWith('webssh2-'))
+      const xtermCss = cssFiles.find((f) => f.startsWith('xterm-'))
+      const code = fs.readFileSync(path.join(publicDir, entry), 'utf-8')
+      assert.ok(code.includes(xtermCss), `bundle missing ref to ${xtermCss}`)
+    })
+  }
+)


### PR DESCRIPTION
## Summary

Switches production build output to content-hashed filenames so the webssh2 gateway can serve client assets with `Cache-Control: public, max-age=31536000, immutable`.

Closes #109.

| Before | After |
| --- | --- |
| `webssh2.bundle.js` | `webssh2-<hash>.js` |
| `webssh2.css` | `webssh2-<hash>.css` |
| `xterm.css` | `xterm-<hash>.css` |
| `client.htm` | `client.htm` (stable, by design) |
| `favicon.ico` | `favicon.ico` (stable, by design) |

## Design decisions (per #109 implementation notes)

- **Hash alphabet (item 1):** `hashCharacters: 'hex'` constrains hashes to `[0-9a-f]`, so every emitted name matches the gateway's hardened `-\w{8,}` immutable pattern. No webssh2 `static-cache.ts` rework needed and no ~12% base64url fallback.
- **client.htm references (item 3):** `index.html` is a real Vite HTML entry, so hashed refs are rewritten at build time; `copyAssetsPlugin` then renames it to `client.htm`. The dynamically imported xterm stylesheet re-points via Vite's dep map. Both are asserted by the new build test.
- **Build-time guarantee (item 1):** `tests/build-output.test.js` asserts every emitted js/css filename matches `-[0-9a-f]{8,}\.(js|css)` and that `client.htm` references the exact emitted names. CI builds before testing, so this runs on every PR.
- **Versioning (item 4):** `feat!:` / BREAKING CHANGE for a release-please major bump.

## Breaking changes

- `webssh2.bundle.js` and `webssh2.css` no longer exist. Downstream consumers must resolve asset names from `client.htm`.
- Requires a coordinated webssh2 release: bump the `webssh2_client` dependency and update `tests/integration/static-cache-headers.vitest.ts` fixtures that hardcode `webssh2.bundle.js` (issue item 2). With hex hashes, no server-side pattern change is required.

## Testing

- `node --test` (includes new `tests/build-output.test.js`, 6 assertions)
- `npm run lint`, `npm run typecheck`, `npm run typecheck:client`
- Manual: inspected `client/public/` listing and `client.htm` script/link tags
