### PR TITLE
chore(lint): enable type-aware no-unsafe ESLint rules for client/src

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -144,6 +144,18 @@
       }
     },
     {
+      "files": ["client/src/**/*.ts", "client/src/**/*.tsx"],
+      "parser": "@typescript-eslint/parser",
+      "parserOptions": { "project": "./client/tsconfig.json" },
+      "rules": {
+        "@typescript-eslint/no-unsafe-assignment": "error",
+        "@typescript-eslint/no-unsafe-call": "error",
+        "@typescript-eslint/no-unsafe-member-access": "error",
+        "@typescript-eslint/no-unsafe-return": "error",
+        "@typescript-eslint/no-unsafe-argument": "error"
+      }
+    },
+    {
       "files": ["tests/**/*.js"],
       "env": { "node": true, "browser": false, "es2021": true },
       "parserOptions": {

--- a/client/src/lib/xterm-solid/components/XTerm.tsx
+++ b/client/src/lib/xterm-solid/components/XTerm.tsx
@@ -1,5 +1,6 @@
 import { createSignal, createEffect, onCleanup } from 'solid-js'
 import { Terminal } from '@xterm/xterm'
+import type { ITerminalAddon } from '@xterm/xterm'
 import type { XTermProps, TerminalRef, XTermEventHandlers } from '../types'
 import { AddonManager } from '../utils/addon-manager'
 import { EventManager } from '../utils/event-manager'
@@ -14,7 +15,15 @@ const loadDefaultStyles = () => {
 }
 
 // Fallback SearchAddon for when the global one is not available
-class FallbackSearchAddon {
+class FallbackSearchAddon implements ITerminalAddon {
+  activate(): void {
+    /* no-op */
+  }
+
+  dispose(): void {
+    /* no-op */
+  }
+
   findNext() {
     return false
   }
@@ -22,6 +31,12 @@ class FallbackSearchAddon {
   findPrevious() {
     return false
   }
+}
+
+// Typed view of optionally-present xterm addons exposed on the global scope
+// (populated by the host bundle). Avoids `as any` member access.
+const addonGlobals = globalThis as typeof globalThis & {
+  SearchAddon?: new (...args: unknown[]) => ITerminalAddon
 }
 
 /**
@@ -97,8 +112,7 @@ export function XTerm(props: XTermProps) {
     },
     findNext: (term: string) => {
       const searchAddon = addonManager?.getAddon(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (globalThis as any).SearchAddon || FallbackSearchAddon
+        addonGlobals.SearchAddon ?? FallbackSearchAddon
       )
       if (searchAddon && 'findNext' in searchAddon) {
         return (searchAddon as { findNext(term: string): boolean }).findNext(
@@ -109,8 +123,7 @@ export function XTerm(props: XTermProps) {
     },
     findPrevious: (term: string) => {
       const searchAddon = addonManager?.getAddon(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (globalThis as any).SearchAddon || FallbackSearchAddon
+        addonGlobals.SearchAddon ?? FallbackSearchAddon
       )
       if (searchAddon && 'findPrevious' in searchAddon) {
         return (

--- a/client/src/lib/xterm-solid/hooks/useXTerm.ts
+++ b/client/src/lib/xterm-solid/hooks/useXTerm.ts
@@ -10,6 +10,13 @@ import type { AddonDefinition, XTermEventHandlers, TerminalRef } from '../types'
 import { AddonManager } from '../utils/addon-manager'
 import { EventManager } from '../utils/event-manager'
 
+// Typed view of optionally-present xterm addons exposed on the global scope
+// (populated by the host bundle). Avoids `as any` member access.
+const addonGlobals = globalThis as typeof globalThis & {
+  FitAddon?: new (...args: unknown[]) => ITerminalAddon
+  SearchAddon?: new (...args: unknown[]) => ITerminalAddon
+}
+
 export interface UseXTermOptions {
   options?: ITerminalOptions & ITerminalInitOnlyOptions
   addons?: AddonDefinition[]
@@ -77,10 +84,19 @@ export function useXTerm(options: UseXTermOptions = {}) {
     fit: () => {
       const fitAddon = addonManager?.getAddon(
         // Dynamic import for better tree shaking
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (globalThis as any).FitAddon ||
-          class FitAddon {
-            fit() {}
+        addonGlobals.FitAddon ??
+          class FitAddon implements ITerminalAddon {
+            activate(): void {
+              /* no-op */
+            }
+
+            dispose(): void {
+              /* no-op */
+            }
+
+            fit(): void {
+              /* no-op */
+            }
           }
       )
       if (fitAddon && 'fit' in fitAddon) {
@@ -89,9 +105,16 @@ export function useXTerm(options: UseXTermOptions = {}) {
     },
     findNext: (term: string) => {
       const searchAddon = addonManager?.getAddon(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (globalThis as any).SearchAddon ||
-          class SearchAddon {
+        addonGlobals.SearchAddon ??
+          class SearchAddon implements ITerminalAddon {
+            activate(): void {
+              /* no-op */
+            }
+
+            dispose(): void {
+              /* no-op */
+            }
+
             findNext() {
               return false
             }
@@ -106,9 +129,16 @@ export function useXTerm(options: UseXTermOptions = {}) {
     },
     findPrevious: (term: string) => {
       const searchAddon = addonManager?.getAddon(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (globalThis as any).SearchAddon ||
-          class SearchAddon {
+        addonGlobals.SearchAddon ??
+          class SearchAddon implements ITerminalAddon {
+            activate(): void {
+              /* no-op */
+            }
+
+            dispose(): void {
+              /* no-op */
+            }
+
             findPrevious() {
               return false
             }


### PR DESCRIPTION
## What

Enables type-aware ESLint for `client/src` and turns on the five `@typescript-eslint/no-unsafe-*` rules at error, aligning with the org supply-chain security policy.

## Why

Red-team review (2026-06-10, finding SC7) flagged that the no-unsafe rules were absent. Measurement showed only 10 violations, all stemming from one root cause in the xterm-solid addon shim.

## Changes

- `.eslintrc.json`: new `client/src` override with `parserOptions.project` plus the five `no-unsafe-*` rules at error
- `lib/xterm-solid/components/XTerm.tsx`, `hooks/useXTerm.ts`: replace `(globalThis as any).FitAddon/SearchAddon` with a typed `globalThis` accessor; fallback addon classes now implement `ITerminalAddon`

## Verification

- `npm run lint`: 0 errors (8 pre-existing prettier warnings in a test file, unchanged)
- `npm run typecheck:client`: clean
- `npm test`: 295/295 pass

## Follow-up

- `strict-boolean-expressions` (218 violations across 36 files) ratchet tracked in #118