### PR TITLE
fix(security): mask credentials in authenticate() debug logging

### DIFF
--- a/client/src/services/socket.ts
+++ b/client/src/services/socket.ts
@@ -35,7 +35,11 @@ import {
 import * as hostKeyStore from './host-key-store.js'
 
 // Import utilities
-import { credentials, sanitizeClientAuthPayload } from '../stores/config.js'
+import {
+  credentials,
+  sanitizeClientAuthPayload,
+  sanitizeClientAuthPayloadForLogging
+} from '../stores/config.js'
 import { createDebouncedResizeEmitter } from '../utils/terminalResize.js'
 import {
   RESIZE_DEBOUNCE_DELAY,
@@ -359,9 +363,9 @@ export class SocketService {
       username: authCredentials.username,
       hasSocket: !!socket(),
       effectiveFormData: effectiveFormData
-        ? sanitizeClientAuthPayload(effectiveFormData)
+        ? sanitizeClientAuthPayloadForLogging(effectiveFormData)
         : null,
-      baseCredentials: sanitizeClientAuthPayload(baseCredentials)
+      baseCredentials: sanitizeClientAuthPayloadForLogging(baseCredentials)
     })
 
     const currentSocket = socket()

--- a/client/src/stores/config.ts
+++ b/client/src/stores/config.ts
@@ -1,6 +1,7 @@
 // client/src/js/stores/config.ts
 import { createSignal, createMemo, createRoot } from 'solid-js'
 import createDebug from 'debug'
+import maskObject from 'jsmasker'
 import { isObject, mergeDeep } from '../utils/index.js'
 import { DEFAULT_AUTH_METHODS } from '../constants.js'
 import type {
@@ -129,6 +130,15 @@ export const sanitizeClientAuthPayload = <
 
   return sanitized
 }
+
+// Sanitization alone leaves credentials for allowed auth methods in
+// cleartext — never log its output directly (issue #112)
+export const sanitizeClientAuthPayloadForLogging = <
+  T extends Partial<ClientAuthenticatePayload>
+>(
+  payload: T
+): Partial<ClientAuthenticatePayload> =>
+  maskObject(sanitizeClientAuthPayload(payload))
 
 // URL parameters signal
 export const [urlParams, setUrlParams] = createSignal<URLSearchParams>(

--- a/tests/auth-log-masking.test.js
+++ b/tests/auth-log-masking.test.js
@@ -1,0 +1,106 @@
+/**
+ * Regression tests for issue #112: cleartext SSH credentials logged to
+ * debug console in authenticate().
+ *
+ * sanitizeClientAuthPayload() only removes credentials for disallowed
+ * auth methods — for allowed methods it returns password, privateKey,
+ * and passphrase in cleartext. Any payload destined for debug logging
+ * must go through sanitizeClientAuthPayloadForLogging(), which masks
+ * the sensitive fields after sanitization.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+await register('./tests/ts-loader.mjs', pathToFileURL('./'))
+
+const { sanitizeClientAuthPayloadForLogging, config, setConfig } =
+  await import('../client/src/stores/config.ts')
+
+const cloneConfig = () =>
+  typeof structuredClone === 'function'
+    ? structuredClone(config())
+    : JSON.parse(JSON.stringify(config()))
+
+const PASSWORD = 'S3cret-Password!'
+const PRIVATE_KEY =
+  '-----BEGIN OPENSSH PRIVATE KEY-----\nKEYMATERIALKEYMATERIAL\n-----END OPENSSH PRIVATE KEY-----'
+const PASSPHRASE = 'hunter2-passphrase'
+
+describe('sanitizeClientAuthPayloadForLogging (issue #112)', () => {
+  let initialConfig
+
+  beforeEach(() => {
+    initialConfig = cloneConfig()
+  })
+
+  afterEach(() => {
+    setConfig(initialConfig)
+  })
+
+  it('emits no cleartext credentials when all auth methods are allowed', () => {
+    setConfig((current) => ({
+      ...current,
+      allowedAuthMethods: ['password', 'publickey', 'keyboard-interactive']
+    }))
+
+    const logged = sanitizeClientAuthPayloadForLogging({
+      host: 'ssh.example.test',
+      username: 'demo',
+      password: PASSWORD,
+      privateKey: PRIVATE_KEY,
+      passphrase: PASSPHRASE
+    })
+
+    const serialized = JSON.stringify(logged)
+    assert.ok(
+      !serialized.includes(PASSWORD),
+      'password must not appear in debug output'
+    )
+    assert.ok(
+      !serialized.includes('KEYMATERIAL'),
+      'private key must not appear in debug output'
+    )
+    assert.ok(
+      !serialized.includes(PASSPHRASE),
+      'passphrase must not appear in debug output'
+    )
+  })
+
+  it('preserves non-sensitive fields for debugging', () => {
+    setConfig((current) => ({
+      ...current,
+      allowedAuthMethods: ['password']
+    }))
+
+    const logged = sanitizeClientAuthPayloadForLogging({
+      host: 'ssh.example.test',
+      username: 'demo',
+      password: PASSWORD
+    })
+
+    assert.equal(logged.host, 'ssh.example.test')
+    assert.equal(logged.username, 'demo')
+  })
+
+  it('still drops credential fields for disallowed auth methods', () => {
+    setConfig((current) => ({
+      ...current,
+      allowedAuthMethods: ['password']
+    }))
+
+    const logged = sanitizeClientAuthPayloadForLogging({
+      host: 'ssh.example.test',
+      username: 'demo',
+      password: PASSWORD,
+      privateKey: PRIVATE_KEY,
+      passphrase: PASSPHRASE
+    })
+
+    assert.ok(!('privateKey' in logged))
+    assert.ok(!('passphrase' in logged))
+    assert.ok(!JSON.stringify(logged).includes(PASSWORD))
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #112 — `authenticate()` logged cleartext SSH credentials (password, private key, passphrase) to the browser debug console.

The `Auth credentials check` debug call passed `effectiveFormData` and `baseCredentials` through `sanitizeClientAuthPayload()` only. That function strips credentials for **disallowed** auth methods but returns them in cleartext for allowed ones, so enabling the `webssh2-client:socket-service` debug namespace (`localStorage.debug`) printed SSH secrets to the console on every connection attempt.

## Changes

- Add `sanitizeClientAuthPayloadForLogging()` in `client/src/stores/config.ts`: wraps `sanitizeClientAuthPayload()` with `maskObject()` (jsmasker masks `password`, `privateKey`, and `passphrase` by default — verified).
- Use it for both sibling objects in the `Auth credentials check` debug call in `client/src/services/socket.ts`. The primary payload on the preceding line was already masked.
- Audited all other `sanitizeClientAuthPayload()` call sites (`app.tsx`, `config.ts`, `socket.ts` setFormData/retryAuthentication) — they feed transport or state, not logs; this was the only leak.

## Tests

`tests/auth-log-masking.test.js` (TDD, watched fail before implementing):

- No cleartext password, private key, or passphrase appears in the serialized logged payload when all auth methods are allowed
- Non-sensitive fields (host, username) are preserved for debugging
- Credential fields for disallowed auth methods are still dropped entirely

Note: the test covers the helper rather than the `authenticate()` call site directly — `socket.ts` cannot be imported under the Node test loader (browser-heavy import graph). The typecheck guarantees the call site uses the new function.

`npm run check:all` passes: lint, format, typecheck, and 298/298 tests.