### PR TITLE
lint: ratchet @typescript-eslint/strict-boolean-expressions to error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -153,7 +153,7 @@
         "@typescript-eslint/no-unsafe-member-access": "error",
         "@typescript-eslint/no-unsafe-return": "error",
         "@typescript-eslint/no-unsafe-argument": "error",
-        "@typescript-eslint/strict-boolean-expressions": "warn"
+        "@typescript-eslint/strict-boolean-expressions": "error"
       }
     },
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -152,7 +152,8 @@
         "@typescript-eslint/no-unsafe-call": "error",
         "@typescript-eslint/no-unsafe-member-access": "error",
         "@typescript-eslint/no-unsafe-return": "error",
-        "@typescript-eslint/no-unsafe-argument": "error"
+        "@typescript-eslint/no-unsafe-argument": "error",
+        "@typescript-eslint/strict-boolean-expressions": "warn"
       }
     },
     {

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -189,7 +189,7 @@ const App: Component = () => {
       onCleanup(() => cleanupUrlListener())
 
       const basicAuthCookie = getBasicAuthCookie()
-      if (basicAuthCookie) {
+      if (basicAuthCookie != null && basicAuthCookie !== '') {
         // Note: Basic auth cookie handling may need to be integrated with reactive config
         setState('isBasicAuthCookiePresent', true)
       } else {
@@ -217,9 +217,10 @@ const App: Component = () => {
       // Set session footer
       const footerProtocol =
         initialConfig.protocol === 'telnet' ? 'telnet' : 'ssh'
-      const footer = initialConfig.ssh.host
-        ? `${footerProtocol}://${initialConfig.ssh.host}:${initialConfig.ssh.port}`
-        : null
+      const footer =
+        initialConfig.ssh.host != null && initialConfig.ssh.host !== ''
+          ? `${footerProtocol}://${initialConfig.ssh.host}:${initialConfig.ssh.port}`
+          : null
       setSessionFooter(footer)
       setGlobalSessionFooter(footer)
 
@@ -261,8 +262,11 @@ const App: Component = () => {
       const hasSessionLog = globalThis.localStorage.getItem(
         'webssh2_session_log'
       )
-      setState('loggedData', !!hasSessionLog)
-      debug('Initialized loggedData state:', !!hasSessionLog)
+      setState('loggedData', hasSessionLog != null && hasSessionLog !== '')
+      debug(
+        'Initialized loggedData state:',
+        hasSessionLog != null && hasSessionLog !== ''
+      )
 
       // Initialize connection
       initializeConnection(initialConfig)
@@ -496,7 +500,7 @@ const App: Component = () => {
         )
       }
 
-      if (Object.keys(clipboardSettings).length > 0 && actions.clipboard) {
+      if (Object.keys(clipboardSettings).length > 0) {
         debug('Updating clipboard settings:', clipboardSettings)
         actions.clipboard.updateSettings(clipboardSettings)
       } else {
@@ -630,9 +634,13 @@ const App: Component = () => {
     try {
       if (currentConfig.autoConnect) {
         const loginInfo: Partial<ClientAuthenticatePayload> = {}
-        if (currentConfig.ssh.host) loginInfo.host = currentConfig.ssh.host
+        if (currentConfig.ssh.host != null && currentConfig.ssh.host !== '')
+          loginInfo.host = currentConfig.ssh.host
         loginInfo.port = currentConfig.ssh.port
-        if (currentConfig.ssh.username)
+        if (
+          currentConfig.ssh.username != null &&
+          currentConfig.ssh.username !== ''
+        )
           loginInfo.username = currentConfig.ssh.username
         connectToServer(loginInfo)
       } else {
@@ -663,11 +671,14 @@ const App: Component = () => {
           initialValues: config()
             ? (Object.fromEntries(
                 Object.entries({
-                  ...(config()!.ssh.host && { host: config()!.ssh.host }),
+                  ...(config()!.ssh.host != null && config()!.ssh.host !== ''
+                    ? { host: config()!.ssh.host }
+                    : {}),
                   ...(config()!.ssh.port && { port: config()!.ssh.port }),
-                  ...(config()!.ssh.username && {
-                    username: config()!.ssh.username
-                  })
+                  ...(config()!.ssh.username != null &&
+                  config()!.ssh.username !== ''
+                    ? { username: config()!.ssh.username }
+                    : {})
                 }).filter(([_, value]) => value != null)
               ) as Partial<ClientAuthenticatePayload>)
             : undefined,
@@ -692,7 +703,11 @@ const App: Component = () => {
       <ErrorModal
         isOpen={isErrorDialogOpen()}
         onClose={() => setIsErrorDialogOpen(false)}
-        message={errorMessage() || 'An error occurred'}
+        message={
+          errorMessage() != null && errorMessage() !== ''
+            ? errorMessage()!
+            : 'An error occurred'
+        }
       />
 
       <ConnectionErrorModal
@@ -721,7 +736,11 @@ const App: Component = () => {
         <PromptModal
           isOpen={!!promptData()}
           onClose={() => setPromptData(null)}
-          title={promptData()?.title || 'Authentication Required'}
+          title={
+            promptData()?.title != null && promptData()?.title !== ''
+              ? promptData()!.title!
+              : 'Authentication Required'
+          }
           prompts={promptData()?.prompts || []}
           onSubmit={handlePromptSubmit}
         />
@@ -764,7 +783,9 @@ const App: Component = () => {
         <HostKeyRejectedModal
           isOpen={isHostKeyRejectedOpen()}
           reason={
-            hostKeyRejectedReason() || 'Connection refused by host key policy'
+            hostKeyRejectedReason() != null && hostKeyRejectedReason() !== ''
+              ? hostKeyRejectedReason()!
+              : 'Connection refused by host key policy'
           }
           onDismiss={() => {
             setIsHostKeyRejectedOpen(false)

--- a/client/src/components/HostKeyStatusIndicator.tsx
+++ b/client/src/components/HostKeyStatusIndicator.tsx
@@ -53,7 +53,11 @@ export const HostKeyStatusIndicator: Component = () => {
   }
 
   return (
-    <Show when={hostKeyVerifyConfig()?.enabled && hostKeyStatus() !== 'none'}>
+    <Show
+      when={
+        hostKeyVerifyConfig()?.enabled === true && hostKeyStatus() !== 'none'
+      }
+    >
       <div
         ref={containerRef}
         class="relative border-l border-neutral-200 px-[10px]"

--- a/client/src/components/LoginModal.tsx
+++ b/client/src/components/LoginModal.tsx
@@ -60,7 +60,7 @@ export const LoginModal: Component<LoginModalProps> = (props) => {
 
   // Reactive private key validation
   const privateKeyValidation = usePrivateKeyValidation(
-    () => formData().privateKey || ''
+    () => formData().privateKey ?? ''
   )
 
   // Field validators for other fields
@@ -73,11 +73,11 @@ export const LoginModal: Component<LoginModalProps> = (props) => {
     ) {
       return props.lockedHost
     }
-    return formData().host || ''
+    return formData().host ?? ''
   }, [ValidationRules.required(), ValidationRules.hostname()])
 
   const usernameValidator = createFieldValidator(
-    () => formData().username || '',
+    () => formData().username ?? '',
     [ValidationRules.required()]
   )
 
@@ -110,14 +110,17 @@ export const LoginModal: Component<LoginModalProps> = (props) => {
 
         // Priority order: host → port → username → password
         // Skip host/port if they're locked
-        if (!hostLocked && (!data.host || data.host.trim() === '')) {
+        if (!hostLocked && (data.host == null || data.host.trim() === '')) {
           hostInputRef?.focus()
           debug('Auto-focused host field')
-        } else if (!hostLocked && (!data.port || data.port === 0)) {
+        } else if (
+          !hostLocked &&
+          (data.port == null || data.port === 0 || Number.isNaN(data.port))
+        ) {
           // Port is unlikely to be empty since default is 22, but check if it's actually empty/0
           portInputRef?.focus()
           debug('Auto-focused port field')
-        } else if (!data.username || data.username.trim() === '') {
+        } else if (data.username == null || data.username.trim() === '') {
           usernameInputRef?.focus()
           debug('Auto-focused username field')
         } else if (supportsPassword()) {
@@ -146,7 +149,7 @@ export const LoginModal: Component<LoginModalProps> = (props) => {
   }
 
   const allowedMethods = createMemo(() =>
-    props.allowedAuthMethods && props.allowedAuthMethods.length > 0
+    props.allowedAuthMethods.length > 0
       ? props.allowedAuthMethods
       : DEFAULT_AUTH_METHODS
   )
@@ -175,13 +178,15 @@ export const LoginModal: Component<LoginModalProps> = (props) => {
   const effectiveHost = createMemo(() =>
     isHostLocked() && props.lockedHost !== undefined
       ? props.lockedHost
-      : formData().host || ''
+      : (formData().host ?? '')
   )
-  const effectivePort = createMemo(() =>
-    isHostLocked() && props.lockedPort !== undefined
-      ? props.lockedPort
-      : formData().port || 22
-  )
+  const effectivePort = createMemo(() => {
+    if (isHostLocked() && props.lockedPort !== undefined) {
+      return props.lockedPort
+    }
+    const port = formData().port
+    return port != null && port !== 0 && !Number.isNaN(port) ? port : 22
+  })
 
   createEffect(() => {
     if (!supportsPublicKey()) {
@@ -396,20 +401,22 @@ export const LoginModal: Component<LoginModalProps> = (props) => {
             class="mb-2 block w-full rounded-md border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
             classList={{
               'border-slate-300 bg-white text-slate-900 placeholder:text-slate-400':
-                !formData().privateKey,
+                formData().privateKey == null || formData().privateKey === '',
               'border-red-500 bg-red-50 text-slate-900 placeholder:text-slate-400':
-                Boolean(
-                  formData().privateKey && !privateKeyValidation.isValid()
-                ),
+                formData().privateKey != null &&
+                formData().privateKey !== '' &&
+                !privateKeyValidation.isValid(),
               'border-green-500 bg-green-50 text-slate-900 placeholder:text-slate-400':
-                Boolean(formData().privateKey && privateKeyValidation.isValid())
+                formData().privateKey != null &&
+                formData().privateKey !== '' &&
+                privateKeyValidation.isValid()
             }}
-            value={formData().privateKey || ''}
+            value={formData().privateKey ?? ''}
             onInput={(e) => updateFormData('privateKey', e.currentTarget.value)}
           ></textarea>
 
           {/* Validation status indicator */}
-          {formData().privateKey && (
+          {formData().privateKey != null && formData().privateKey !== '' && (
             <div class="absolute right-2 top-2">
               {privateKeyValidation.isValid() ? (
                 <span
@@ -428,25 +435,30 @@ export const LoginModal: Component<LoginModalProps> = (props) => {
         </div>
 
         {/* Validation error message */}
-        {formData().privateKey && !privateKeyValidation.isValid() && (
-          <div class="mb-2 text-sm">
-            <p class="text-red-600">{privateKeyValidation.error()}</p>
-            {privateKeyValidation.suggestion() && (
-              <p class="mt-1 text-gray-600">
-                {privateKeyValidation.suggestion()}
-              </p>
-            )}
-          </div>
-        )}
+        {formData().privateKey != null &&
+          formData().privateKey !== '' &&
+          !privateKeyValidation.isValid() && (
+            <div class="mb-2 text-sm">
+              <p class="text-red-600">{privateKeyValidation.error()}</p>
+              {privateKeyValidation.suggestion() != null &&
+                privateKeyValidation.suggestion() !== '' && (
+                  <p class="mt-1 text-gray-600">
+                    {privateKeyValidation.suggestion()}
+                  </p>
+                )}
+            </div>
+          )}
 
         {/* Key format badge */}
-        {formData().privateKey && privateKeyValidation.isValid() && (
-          <div class="mb-2">
-            <span class="inline-flex items-center rounded-full bg-green-100 px-2 py-1 text-xs font-medium text-green-800">
-              {privateKeyValidation.format()} format detected
-            </span>
-          </div>
-        )}
+        {formData().privateKey != null &&
+          formData().privateKey !== '' &&
+          privateKeyValidation.isValid() && (
+            <div class="mb-2">
+              <span class="inline-flex items-center rounded-full bg-green-100 px-2 py-1 text-xs font-medium text-green-800">
+                {privateKeyValidation.format()} format detected
+              </span>
+            </div>
+          )}
 
         <div class="mb-2">
           <input
@@ -475,7 +487,7 @@ export const LoginModal: Component<LoginModalProps> = (props) => {
             enterkeyhint="go"
             placeholder="Key password (if encrypted)"
             class="block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
-            value={formData().passphrase || ''}
+            value={formData().passphrase ?? ''}
             onInput={(e) => updateFormData('passphrase', e.currentTarget.value)}
           />
         </div>
@@ -559,7 +571,7 @@ export const LoginModal: Component<LoginModalProps> = (props) => {
                 spellcheck={false}
                 enterkeyhint="next"
                 class="block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                value={formData().host || ''}
+                value={formData().host ?? ''}
                 onInput={(e) => updateFormData('host', e.currentTarget.value)}
               />
             </div>
@@ -582,7 +594,12 @@ export const LoginModal: Component<LoginModalProps> = (props) => {
                 inputmode="numeric"
                 pattern="[0-9]*"
                 class="block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                value={formData().port || String(defaultPort())}
+                value={(() => {
+                  const port = formData().port
+                  return port != null && port !== 0 && !Number.isNaN(port)
+                    ? port
+                    : String(defaultPort())
+                })()}
                 onInput={(e) =>
                   updateFormData(
                     'port',
@@ -608,7 +625,7 @@ export const LoginModal: Component<LoginModalProps> = (props) => {
               spellcheck={false}
               enterkeyhint="next"
               class="block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
-              value={formData().username || ''}
+              value={formData().username ?? ''}
               onInput={(e) => updateFormData('username', e.currentTarget.value)}
             />
           </div>
@@ -630,7 +647,7 @@ export const LoginModal: Component<LoginModalProps> = (props) => {
                       spellcheck={false}
                       enterkeyhint="go"
                       class="block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                      value={formData().password || ''}
+                      value={formData().password ?? ''}
                       onInput={(e) =>
                         updateFormData('password', e.currentTarget.value)
                       }

--- a/client/src/components/Modal.tsx
+++ b/client/src/components/Modal.tsx
@@ -43,12 +43,12 @@ export const Modal: Component<ModalProps> = (props) => {
 
         // Focus trap - focus on first focusable element using another requestAnimationFrame for proper timing
         requestAnimationFrame(() => {
-          if (dialogRef) {
+          if (dialogRef != null) {
             const focusableElements = dialogRef.querySelectorAll(
               'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
             )
-            const firstElement = focusableElements[0] as HTMLElement
-            if (firstElement) {
+            const firstElement = focusableElements[0] as HTMLElement | undefined
+            if (firstElement != null) {
               firstElement.focus()
             }
           }
@@ -105,7 +105,7 @@ export const Modal: Component<ModalProps> = (props) => {
       <Show when={props.isOpen}>
         <dialog
           ref={dialogRef}
-          class={`fixed inset-0 z-50 flex items-center justify-center bg-black/50 ${props.class || ''}`}
+          class={`fixed inset-0 z-50 flex items-center justify-center bg-black/50 ${props.class ?? ''}`}
           onClick={handleDialogClick}
           aria-modal="true"
         >
@@ -182,9 +182,7 @@ export const PromptModal: Component<PromptModalProps> = (props) => {
 
   // Initialize responses array when prompts change
   createEffect(() => {
-    if (props.prompts) {
-      setResponses(new Array(props.prompts.length).fill(''))
-    }
+    setResponses(new Array(props.prompts.length).fill(''))
   })
 
   const handleInputChange = (index: number, value: string) => {
@@ -229,7 +227,7 @@ export const PromptModal: Component<PromptModalProps> = (props) => {
                       id={inputId}
                       type={prompt.echo ? 'text' : 'password'}
                       class="block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                      value={responses()[index()] || ''}
+                      value={responses()[index()] ?? ''}
                       onInput={(e) =>
                         handleInputChange(index(), e.currentTarget.value)
                       }

--- a/client/src/components/SpecialKeysPanel.tsx
+++ b/client/src/components/SpecialKeysPanel.tsx
@@ -105,11 +105,11 @@ export const SpecialKeysPanel: Component<SpecialKeysPanelProps> = (props) => {
                         <button
                           type="button"
                           class={`rounded px-1 py-1.5 font-mono text-xs transition-colors ${
-                            key.browserReserved
+                            key.browserReserved === true
                               ? 'border border-dashed border-amber-700 bg-neutral-700 text-amber-400 hover:bg-neutral-600'
                               : 'bg-neutral-700 text-neutral-200 hover:bg-neutral-600'
                           }`}
-                          title={`${key.description}${key.browserReserved ? ' (browser-reserved)' : ''}`}
+                          title={`${key.description}${key.browserReserved === true ? ' (browser-reserved)' : ''}`}
                           onClick={() => handleSendKey(key.sequence)}
                         >
                           {key.label}

--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -252,7 +252,7 @@ export const TerminalComponent: Component<TerminalComponentProps> = (props) => {
 
     // Fit terminal after mount with multiple attempts for proper sizing
     const fitTerminal = () => {
-      if (fitAddonInstance && ref.terminal) {
+      if (ref.terminal) {
         fitAddonInstance.fit()
         const dims = { cols: ref.terminal.cols, rows: ref.terminal.rows }
         debug('Terminal fitted, dimensions:', dims.cols, 'x', dims.rows)
@@ -325,7 +325,7 @@ export const TerminalComponent: Component<TerminalComponentProps> = (props) => {
           if (clipboard && term) {
             const manager = clipboard.getClipboardManager()
             const text = await manager.readText()
-            if (text) {
+            if (text != null && text !== '') {
               term.paste(text)
             }
           }
@@ -562,7 +562,10 @@ export const TerminalComponent: Component<TerminalComponentProps> = (props) => {
     onTitleChange: handleTitleChange,
     onBell: playBellSound,
     onMount: handleTerminalMount,
-    class: props.class || 'terminal-container',
+    class:
+      props.class != null && props.class !== ''
+        ? props.class
+        : 'terminal-container',
     style: {
       width: '100%',
       height: '100%'

--- a/client/src/components/TerminalSearch.tsx
+++ b/client/src/components/TerminalSearch.tsx
@@ -156,7 +156,7 @@ export const TerminalSearch: Component<TerminalSearchProps> = (props) => {
   // Set up search results listener
   createEffect(() => {
     const actions = props.terminalActions
-    if (actions && actions.search.onSearchResults) {
+    if (actions) {
       // Clean up previous listener
       if (searchResultsCleanup) {
         searchResultsCleanup()
@@ -190,7 +190,7 @@ export const TerminalSearch: Component<TerminalSearchProps> = (props) => {
   return (
     <Show when={isSearchVisible()}>
       <div
-        class={`absolute right-2 top-2 z-50 flex items-center gap-1 rounded-lg border border-neutral-300 bg-white p-2 shadow-lg ${props.class || ''}`}
+        class={`absolute right-2 top-2 z-50 flex items-center gap-1 rounded-lg border border-neutral-300 bg-white p-2 shadow-lg ${props.class ?? ''}`}
         onKeyDown={handleKeyDown}
       >
         <form onSubmit={handleSearchSubmit} class="contents">

--- a/client/src/components/TerminalSettingsModal.tsx
+++ b/client/src/components/TerminalSettingsModal.tsx
@@ -191,11 +191,29 @@ export const TerminalSettingsModal: Component<TerminalSettingsModalProps> = (
           : ''
       setThemeJsonError(null)
       setSettings({
-        fontSize: stored.fontSize || defaultSettings.fontSize,
-        fontFamily: stored.fontFamily || defaultSettings.fontFamily,
+        fontSize:
+          stored.fontSize != null &&
+          stored.fontSize !== 0 &&
+          !Number.isNaN(stored.fontSize)
+            ? stored.fontSize
+            : defaultSettings.fontSize,
+        fontFamily:
+          stored.fontFamily != null && stored.fontFamily !== ''
+            ? stored.fontFamily
+            : defaultSettings.fontFamily,
         cursorBlink: stored.cursorBlink ?? defaultSettings.cursorBlink,
-        scrollback: stored.scrollback || defaultSettings.scrollback,
-        tabStopWidth: stored.tabStopWidth || defaultSettings.tabStopWidth,
+        scrollback:
+          stored.scrollback != null &&
+          stored.scrollback !== 0 &&
+          !Number.isNaN(stored.scrollback)
+            ? stored.scrollback
+            : defaultSettings.scrollback,
+        tabStopWidth:
+          stored.tabStopWidth != null &&
+          stored.tabStopWidth !== 0 &&
+          !Number.isNaN(stored.tabStopWidth)
+            ? stored.tabStopWidth
+            : defaultSettings.tabStopWidth,
         bellStyle: (stored.bellStyle as 'sound' | 'none') || 'none',
         clipboardAutoSelectToCopy:
           stored.clipboardAutoSelectToCopy ??
@@ -1000,8 +1018,14 @@ export const TerminalSettingsModal: Component<TerminalSettingsModalProps> = (
                                 </span>
                               </div>
                               <div class="mt-0.5 truncate font-mono text-xs text-slate-500">
-                                {hostKeyFingerprints()[hostPort]?.[algo] ||
-                                  'Computing...'}
+                                {(() => {
+                                  const fingerprint =
+                                    hostKeyFingerprints()[hostPort]?.[algo]
+                                  return fingerprint != null &&
+                                    fingerprint !== ''
+                                    ? fingerprint
+                                    : 'Computing...'
+                                })()}
                               </div>
                             </div>
                             <button
@@ -1096,7 +1120,11 @@ export const TerminalSettingsModal: Component<TerminalSettingsModalProps> = (
                             setAddKeyPublicKey('')
                             refreshFingerprints()
                           } else {
-                            setAddKeyError(result.error || 'Failed to add key')
+                            setAddKeyError(
+                              result.error != null && result.error !== ''
+                                ? result.error
+                                : 'Failed to add key'
+                            )
                           }
                         }}
                       >
@@ -1155,7 +1183,9 @@ export const TerminalSettingsModal: Component<TerminalSettingsModalProps> = (
                             refreshFingerprints()
                           } else {
                             setImportError(
-                              result.error || 'Failed to import keys'
+                              result.error != null && result.error !== ''
+                                ? result.error
+                                : 'Failed to import keys'
                             )
                           }
                         }

--- a/client/src/components/prompts/UniversalPrompt.tsx
+++ b/client/src/components/prompts/UniversalPrompt.tsx
@@ -97,7 +97,7 @@ export const UniversalPrompt: Component<UniversalPromptProps> = (props) => {
   const handleFormSubmit = (e: Event) => {
     e.preventDefault()
     // Find the default button or first primary button
-    const defaultButton = props.prompt.buttons?.find((b) => b.default)
+    const defaultButton = props.prompt.buttons?.find((b) => b.default === true)
     const primaryButton = props.prompt.buttons?.find(
       (b) => b.variant === 'primary'
     )
@@ -209,15 +209,15 @@ export const UniversalPrompt: Component<UniversalPromptProps> = (props) => {
             <For each={buttons()}>
               {(button) => (
                 <button
-                  type={button.default ? 'submit' : 'button'}
+                  type={button.default === true ? 'submit' : 'button'}
                   onClick={
-                    button.default
+                    button.default === true
                       ? undefined
                       : () => handleButtonClick(button.action)
                   }
                   class={`inline-flex items-center justify-center rounded-md border border-transparent px-3 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 ${getButtonVariantClasses(button.variant)}`}
                   autofocus={
-                    button.default &&
+                    button.default === true &&
                     (props.prompt.inputs === undefined ||
                       props.prompt.inputs.length === 0)
                   }

--- a/client/src/components/sftp/FileBrowser.tsx
+++ b/client/src/components/sftp/FileBrowser.tsx
@@ -79,7 +79,7 @@ export const FileBrowser: Component<FileBrowserProps> = (props) => {
   // Error display with auto-clear
   createEffect(() => {
     const error = sftpStore.error
-    if (error) {
+    if (error != null && error !== '') {
       const timeout = setTimeout(() => {
         sftpStore.clearError()
       }, 5000)
@@ -92,7 +92,7 @@ export const FileBrowser: Component<FileBrowserProps> = (props) => {
     <Show when={sftpStore.isOpen}>
       <div
         class={`flex h-72 shrink-0 flex-col overflow-hidden border-t border-neutral-600 bg-neutral-900 ${
-          props.class || ''
+          props.class ?? ''
         }`}
       >
         {/* Toolbar */}

--- a/client/src/components/sftp/FileEntry.tsx
+++ b/client/src/components/sftp/FileEntry.tsx
@@ -48,7 +48,7 @@ export const FileEntry: Component<FileEntryProps> = (props) => {
   return (
     <div
       class={`flex cursor-pointer items-center gap-2 px-2 py-1 text-sm hover:bg-neutral-700 ${
-        props.selected ? 'bg-blue-900/50' : ''
+        props.selected === true ? 'bg-blue-900/50' : ''
       }`}
       onClick={handleClick}
       onKeyDown={handleKeyDown}

--- a/client/src/components/sftp/FileIcon.tsx
+++ b/client/src/components/sftp/FileIcon.tsx
@@ -35,7 +35,8 @@ interface FileIconProps {
  * Get the appropriate icon component based on file type and extension
  */
 export const FileIcon: Component<FileIconProps> = (props) => {
-  const iconClass = () => props.class || 'size-4'
+  const iconClass = () =>
+    props.class != null && props.class !== '' ? props.class : 'size-4'
 
   // Directory
   if (props.entry.type === 'directory') {

--- a/client/src/components/sftp/FileInfoModal.tsx
+++ b/client/src/components/sftp/FileInfoModal.tsx
@@ -163,7 +163,10 @@ export const FileInfoModal: Component<FileInfoModalProps> = (props) => {
               </dt>
             </div>
             <dd class="text-right font-mono text-neutral-100">
-              {props.entry?.permissions || '--'}
+              {props.entry?.permissions != null &&
+              props.entry.permissions !== ''
+                ? props.entry.permissions
+                : '--'}
             </dd>
 
             {/* Owner */}
@@ -174,7 +177,9 @@ export const FileInfoModal: Component<FileInfoModalProps> = (props) => {
               </dt>
             </div>
             <dd class="text-right text-neutral-100">
-              {props.entry?.owner || '--'}
+              {props.entry?.owner != null && props.entry.owner !== ''
+                ? props.entry.owner
+                : '--'}
             </dd>
 
             {/* Group */}
@@ -185,7 +190,9 @@ export const FileInfoModal: Component<FileInfoModalProps> = (props) => {
               </dt>
             </div>
             <dd class="text-right text-neutral-100">
-              {props.entry?.group || '--'}
+              {props.entry?.group != null && props.entry.group !== ''
+                ? props.entry.group
+                : '--'}
             </dd>
           </dl>
         </div>

--- a/client/src/components/sftp/SftpToolbar.tsx
+++ b/client/src/components/sftp/SftpToolbar.tsx
@@ -140,7 +140,7 @@ export const SftpToolbar: Component<SftpToolbarProps> = (props) => {
           disabled={props.loading}
         >
           <RefreshCw
-            class={`size-4 ${props.loading ? 'animate-spin' : ''}`}
+            class={`size-4 ${props.loading === true ? 'animate-spin' : ''}`}
             aria-hidden="true"
           />
         </button>
@@ -149,14 +149,20 @@ export const SftpToolbar: Component<SftpToolbarProps> = (props) => {
         <button
           type="button"
           class={`rounded p-1.5 hover:bg-neutral-700 ${
-            props.showHidden
+            props.showHidden === true
               ? 'text-blue-400'
               : 'text-neutral-400 hover:text-white'
           }`}
           onClick={props.onToggleHidden}
-          title={props.showHidden ? 'Hide hidden files' : 'Show hidden files'}
+          title={
+            props.showHidden === true
+              ? 'Hide hidden files'
+              : 'Show hidden files'
+          }
           aria-label={
-            props.showHidden ? 'Hide hidden files' : 'Show hidden files'
+            props.showHidden === true
+              ? 'Hide hidden files'
+              : 'Show hidden files'
           }
           aria-pressed={props.showHidden}
         >

--- a/client/src/components/sftp/TransferProgress.tsx
+++ b/client/src/components/sftp/TransferProgress.tsx
@@ -48,7 +48,9 @@ export const TransferProgress: Component<TransferProgressProps> = (props) => {
       case 'completed':
         return 'Complete'
       case 'failed':
-        return props.transfer.error || 'Failed'
+        return props.transfer.error != null && props.transfer.error !== ''
+          ? props.transfer.error
+          : 'Failed'
       case 'cancelled':
         return 'Cancelled'
       case 'paused':

--- a/client/src/components/sftp/UploadDropzone.tsx
+++ b/client/src/components/sftp/UploadDropzone.tsx
@@ -23,7 +23,7 @@ export const UploadDropzone: Component<UploadDropzoneProps> = (props) => {
   const handleDragEnter = (e: DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    if (props.disabled) return
+    if (props.disabled === true) return
 
     setDragCounter((c) => c + 1)
     if (e.dataTransfer?.items && e.dataTransfer.items.length > 0) {
@@ -54,7 +54,7 @@ export const UploadDropzone: Component<UploadDropzoneProps> = (props) => {
     setIsDragOver(false)
     setDragCounter(0)
 
-    if (props.disabled) return
+    if (props.disabled === true) return
 
     const files = e.dataTransfer?.files
     if (files && files.length > 0) {

--- a/client/src/lib/clipboard/clipboard-manager.ts
+++ b/client/src/lib/clipboard/clipboard-manager.ts
@@ -24,10 +24,13 @@ export class ClipboardManager {
   }
 
   isSupported(): boolean {
-    return !!(
-      navigator.clipboard &&
-      typeof navigator.clipboard.readText === 'function' &&
-      typeof navigator.clipboard.writeText === 'function'
+    // navigator.clipboard is typed as non-nullable in lib.dom, but is absent
+    // at runtime in insecure contexts and older browsers.
+    const clipboard = navigator.clipboard as Clipboard | undefined
+    return (
+      clipboard != null &&
+      typeof clipboard.readText === 'function' &&
+      typeof clipboard.writeText === 'function'
     )
   }
 

--- a/client/src/lib/clipboard/terminal-clipboard-integration.ts
+++ b/client/src/lib/clipboard/terminal-clipboard-integration.ts
@@ -138,7 +138,11 @@ export class TerminalClipboardIntegration {
     this.mouseUpHandler = async () => {
       setTimeout(async () => {
         const selection = this.terminal?.getSelection()
-        if (selection && selection !== lastSelection) {
+        if (
+          selection != null &&
+          selection !== '' &&
+          selection !== lastSelection
+        ) {
           lastSelection = selection
           debug(
             'Auto-copying selection to clipboard:',
@@ -177,7 +181,7 @@ export class TerminalClipboardIntegration {
         e.preventDefault()
         debug('Middle-click paste triggered')
         const text = await this.clipboardManager.readText()
-        if (text && this.terminal) {
+        if (text != null && text !== '' && this.terminal) {
           const preview =
             text.substring(0, 50) + (text.length > 50 ? '...' : '')
           debug('Pasting from clipboard:', preview)
@@ -241,7 +245,7 @@ export class TerminalClipboardIntegration {
 
     debug('Keyboard shortcut paste triggered')
     const text = await this.clipboardManager.readText()
-    if (text) {
+    if (text != null && text !== '') {
       const preview = text.substring(0, 50) + (text.length > 50 ? '...' : '')
       debug('Keyboard paste, text:', preview)
       this.terminal.paste(text)

--- a/client/src/lib/xterm-solid/components/XTerm.tsx
+++ b/client/src/lib/xterm-solid/components/XTerm.tsx
@@ -65,8 +65,8 @@ export function XTerm(props: XTermProps) {
   const [terminal, setTerminal] = createSignal<Terminal>()
   const [containerRef, setContainerRef] = createSignal<HTMLDivElement>()
 
-  let addonManager: AddonManager
-  let eventManager: EventManager
+  let addonManager: AddonManager | undefined
+  let eventManager: EventManager | undefined
   let mountCleanup: (() => void) | undefined
 
   // Create terminal reference for imperative access
@@ -94,10 +94,9 @@ export function XTerm(props: XTermProps) {
     // Addon-specific methods (available only if addons are loaded)
     fit: () => {
       // Try to get FitAddon from our addon manager
-      const addons = addonManager?.getAllAddons() || []
+      const addons = addonManager?.getAllAddons() ?? []
       const fitAddon = addons.find(
         (addon) =>
-          addon &&
           addon.constructor.name === 'FitAddon' &&
           typeof (addon as unknown as Record<string, unknown>)['fit'] ===
             'function'
@@ -193,7 +192,7 @@ export function XTerm(props: XTermProps) {
     }
 
     // Auto-focus if requested
-    if (props.autoFocus) {
+    if (props.autoFocus === true) {
       // Use requestAnimationFrame to ensure terminal is fully initialized
       requestAnimationFrame(() => term.focus())
     }
@@ -204,7 +203,7 @@ export function XTerm(props: XTermProps) {
   // Update event handlers when props change
   createEffect((prevHandlers) => {
     const term = terminal()
-    if (!term || !eventManager) return undefined
+    if (term == null || eventManager == null) return undefined
 
     const currentHandlers: XTermEventHandlers = {}
     if (props.onBell) currentHandlers.onBell = props.onBell
@@ -249,10 +248,10 @@ export function XTerm(props: XTermProps) {
     }
 
     // Cleanup managers
-    if (eventManager) {
+    if (eventManager != null) {
       eventManager.dispose()
     }
-    if (addonManager) {
+    if (addonManager != null) {
       addonManager.dispose()
     }
 
@@ -265,7 +264,9 @@ export function XTerm(props: XTermProps) {
   return (
     <div
       ref={setContainerRef}
-      class={props.class || 'size-full'}
+      class={
+        props.class != null && props.class !== '' ? props.class : 'size-full'
+      }
       style={props.style}
     />
   )

--- a/client/src/lib/xterm-solid/hooks/useXTerm.ts
+++ b/client/src/lib/xterm-solid/hooks/useXTerm.ts
@@ -183,7 +183,7 @@ export function useXTerm(options: UseXTermOptions = {}) {
     currentTerminalRef = createTerminalRef(term)
 
     // Auto-focus if requested
-    if (options.autoFocus) {
+    if (options.autoFocus === true) {
       setTimeout(() => term.focus(), 0)
     }
 

--- a/client/src/services/host-key-store.ts
+++ b/client/src/services/host-key-store.ts
@@ -52,7 +52,7 @@ export type LookupResult =
 function loadStore(): StoreData {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) {
+    if (raw == null || raw === '') {
       return { version: 1, keys: {} }
     }
     const parsed = JSON.parse(raw) as unknown
@@ -192,7 +192,7 @@ export function remove(host: string, port: number, algorithm?: string): void {
     return
   }
 
-  if (algorithm) {
+  if (algorithm != null && algorithm !== '') {
     delete data.keys[hostPortKey][algorithm]
     // Clean up empty host entries
     if (Object.keys(data.keys[hostPortKey]).length === 0) {
@@ -206,7 +206,7 @@ export function remove(host: string, port: number, algorithm?: string): void {
   debug(
     'Removed key(s) for %s%s',
     hostPortKey,
-    algorithm ? ` algorithm ${algorithm}` : ''
+    algorithm != null && algorithm !== '' ? ` algorithm ${algorithm}` : ''
   )
 }
 

--- a/client/src/services/logging.ts
+++ b/client/src/services/logging.ts
@@ -48,7 +48,7 @@ class LoggingServiceImpl implements LoggingService {
   addToLog(data: string): void {
     if (!state.sessionLogEnable) return
 
-    let sessionLog = window.localStorage.getItem(LOG_KEY) || ''
+    let sessionLog = window.localStorage.getItem(LOG_KEY) ?? ''
     const isNewLog = sessionLog === ''
 
     sessionLog += data
@@ -70,7 +70,7 @@ class LoggingServiceImpl implements LoggingService {
     const logStartMessage = `Log Start for ${footer} - ${formatDate(new Date())}\r\n\r\n`
 
     // Add start message to log
-    let sessionLog = window.localStorage.getItem(LOG_KEY) || ''
+    let sessionLog = window.localStorage.getItem(LOG_KEY) ?? ''
     sessionLog += logStartMessage
     window.localStorage.setItem(LOG_KEY, sessionLog)
     window.localStorage.setItem(LOG_DATE_KEY, new Date().toISOString())
@@ -83,12 +83,13 @@ class LoggingServiceImpl implements LoggingService {
     setState('sessionLogEnable', false)
 
     // Add end message if we have log data
-    const hasLogData = !!window.localStorage.getItem(LOG_KEY)
+    const storedLog = window.localStorage.getItem(LOG_KEY)
+    const hasLogData = storedLog != null && storedLog !== ''
     if (hasLogData) {
       const footer = sessionFooter ?? ''
       const logEndMessage = `\r\n\r\nLog End for ${footer} - ${formatDate(new Date())}\r\n`
 
-      let sessionLog = window.localStorage.getItem(LOG_KEY) || ''
+      let sessionLog = window.localStorage.getItem(LOG_KEY) ?? ''
       sessionLog += logEndMessage
       window.localStorage.setItem(LOG_KEY, sessionLog)
 
@@ -98,7 +99,7 @@ class LoggingServiceImpl implements LoggingService {
 
   clearLog(): void {
     const sessionLog = window.localStorage.getItem(LOG_KEY)
-    if (!sessionLog) {
+    if (sessionLog == null || sessionLog === '') {
       debug('No session log found to clear')
       return
     }
@@ -114,8 +115,7 @@ class LoggingServiceImpl implements LoggingService {
 
   downloadLog(): void {
     const sessionLog = window.localStorage.getItem(LOG_KEY)
-    const hasLogData = !!sessionLog
-    if (!sessionLog || !hasLogData) {
+    if (sessionLog == null || sessionLog === '') {
       debug('No log data available for download')
       return
     }
@@ -160,7 +160,12 @@ class LoggingServiceImpl implements LoggingService {
     const savedLog = window.localStorage.getItem(LOG_KEY)
     const savedDate = window.localStorage.getItem(LOG_DATE_KEY)
 
-    if (savedLog && savedDate) {
+    if (
+      savedLog != null &&
+      savedLog !== '' &&
+      savedDate != null &&
+      savedDate !== ''
+    ) {
       const restoreLog = window.confirm(
         `A saved session log from ${new Date(savedDate).toLocaleString()} was found. Would you like to download it?`
       )

--- a/client/src/services/sftp-service.ts
+++ b/client/src/services/sftp-service.ts
@@ -367,7 +367,8 @@ function handleDownloadReady(response: SftpDownloadReadyResponse): void {
     pending.resolve(response)
     // The user-clicked name is authoritative; flag a server echo that differs
     if (
-      pending.requestedFileName &&
+      pending.requestedFileName != null &&
+      pending.requestedFileName !== '' &&
       pending.requestedFileName !== response.fileName
     ) {
       debug(
@@ -516,7 +517,7 @@ function handleError(response: SftpErrorResponse): void {
 
   // Reject operation-specific requests by path if provided
   let pathMatchFound = false
-  if (response.path) {
+  if (response.path != null && response.path !== '') {
     // Try to find and reject by exact path match
     const listKey = `list:${response.path}`
     const statKey = `stat:${response.path}`
@@ -540,7 +541,7 @@ function handleError(response: SftpErrorResponse): void {
   // or no path provided, use operation-based prefix matching
   if (!pathMatchFound && response.operation) {
     const prefix = getOperationPrefix(response.operation)
-    if (prefix) {
+    if (prefix != null) {
       rejectPendingByPrefix(prefix, error)
     }
   }
@@ -635,7 +636,7 @@ export async function listDirectory(
   socketInstance.emit('sftp-list', request)
 
   const response = await responsePromise
-  if (response.error) {
+  if (response.error != null && response.error !== '') {
     throw new Error(response.error)
   }
 
@@ -665,8 +666,12 @@ export async function stat(path: string): Promise<SftpFileEntry> {
   socketInstance.emit('sftp-stat', request)
 
   const response = await responsePromise
-  if (response.error || !response.entry) {
-    throw new Error(response.error || 'File not found')
+  if ((response.error != null && response.error !== '') || !response.entry) {
+    throw new Error(
+      response.error != null && response.error !== ''
+        ? response.error
+        : 'File not found'
+    )
   }
 
   return response.entry
@@ -693,7 +698,11 @@ export async function mkdir(path: string, mode?: number): Promise<void> {
 
   const response = await responsePromise
   if (!response.success) {
-    throw new Error(response.error || 'Failed to create directory')
+    throw new Error(
+      response.error != null && response.error !== ''
+        ? response.error
+        : 'Failed to create directory'
+    )
   }
 }
 
@@ -721,7 +730,11 @@ export async function deleteFile(
 
   const response = await responsePromise
   if (!response.success) {
-    throw new Error(response.error || 'Failed to delete')
+    throw new Error(
+      response.error != null && response.error !== ''
+        ? response.error
+        : 'Failed to delete'
+    )
   }
 }
 

--- a/client/src/services/socket.ts
+++ b/client/src/services/socket.ts
@@ -326,8 +326,9 @@ export class SocketService {
   }
 
   private getWebSocketUrl(): string {
-    if (config?.socket?.url) {
-      const url = new URL(config.socket.url)
+    const configuredUrl = config?.socket?.url
+    if (configuredUrl != null && configuredUrl !== '') {
+      const url = new URL(configuredUrl)
       url.protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
       return url.toString()
     }
@@ -369,14 +370,21 @@ export class SocketService {
     })
 
     const currentSocket = socket()
-    if (authCredentials.host && authCredentials.username && currentSocket) {
+    if (
+      authCredentials.host != null &&
+      authCredentials.host !== '' &&
+      authCredentials.username != null &&
+      authCredentials.username !== '' &&
+      currentSocket
+    ) {
       currentSocket.emit('authenticate', authCredentials)
       setConnectionStatus('Authenticating...')
       setConnectionStatusColor('orange')
     } else {
       debug('Authentication failed - missing requirements', {
-        host: !!authCredentials.host,
-        username: !!authCredentials.username,
+        host: authCredentials.host != null && authCredentials.host !== '',
+        username:
+          authCredentials.username != null && authCredentials.username !== '',
         socket: !!currentSocket
       })
       if (onDisconnectCallback) {
@@ -417,15 +425,19 @@ export class SocketService {
         case 'auth_result':
           this.handleAuthResult({
             success: Boolean(data.success),
-            ...(data.message && { message: data.message })
+            ...(data.message != null && data.message !== ''
+              ? { message: data.message }
+              : {})
           })
           break
         case 'keyboard-interactive':
-          if ('prompts' in data && data.prompts) {
+          if (data.prompts != null) {
             this.handleKeyboardInteractive({
-              prompts: data.prompts as Array<{ prompt: string; echo: boolean }>,
-              ...('name' in data && data.name
-                ? { name: data.name as string }
+              prompts: data.prompts,
+              ...('name' in data &&
+              typeof data.name === 'string' &&
+              data.name !== ''
+                ? { name: data.name }
                 : {})
             })
           }
@@ -752,7 +764,10 @@ export class SocketService {
     debug('Keyboard interactive authentication', data)
     // Use the reactive prompt modal
     setPromptData({
-      title: data.name || 'Authentication Required',
+      title:
+        data.name != null && data.name !== ''
+          ? data.name
+          : 'Authentication Required',
       prompts: data.prompts
     })
   }

--- a/client/src/services/ui.ts
+++ b/client/src/services/ui.ts
@@ -18,7 +18,10 @@ export const updateElement = (
       ? { text: content.text, background: content.background }
       : { text: content, background: color }
 
-  const sanitizedColor = background ? sanitizeColor(background) : undefined
+  const sanitizedColor =
+    background != null && background !== ''
+      ? sanitizeColor(background)
+      : undefined
 
   debug('updateElement', { elementName, text, sanitizedColor })
 
@@ -26,14 +29,16 @@ export const updateElement = (
     case 'status':
       // Use socket-service status signals
       setConnectionStatus(text)
-      if (sanitizedColor) {
+      if (sanitizedColor != null && sanitizedColor !== '') {
         setConnectionStatusColor(sanitizedColor)
       }
       break
     case 'header':
       setHeaderContent({
         text,
-        ...(sanitizedColor && { background: sanitizedColor })
+        ...(sanitizedColor != null && sanitizedColor !== ''
+          ? { background: sanitizedColor }
+          : {})
       })
       break
     case 'footer':

--- a/client/src/stores/config.ts
+++ b/client/src/stores/config.ts
@@ -177,7 +177,7 @@ export const configWithUrlOverrides = () => {
   const passphrase = params.get('passphrase')
   const sshterm = params.get('sshterm')
 
-  const parsedPort = port ? parseInt(port, 10) : NaN
+  const parsedPort = port != null && port !== '' ? parseInt(port, 10) : NaN
   const sanitizedPort = Number.isNaN(parsedPort) ? 22 : parsedPort
 
   const passwordTrimmed = typeof password === 'string' ? password.trim() : ''
@@ -185,20 +185,20 @@ export const configWithUrlOverrides = () => {
     typeof privateKey === 'string' ? privateKey.trim() : ''
 
   if (
-    host ||
-    port ||
-    username ||
-    (passwordAllowed && passwordTrimmed) ||
-    (publicKeyAllowed && privateKeyTrimmed) ||
-    (publicKeyAllowed && passphrase) ||
-    sshterm
+    (host != null && host !== '') ||
+    (port != null && port !== '') ||
+    (username != null && username !== '') ||
+    (passwordAllowed && passwordTrimmed !== '') ||
+    (publicKeyAllowed && privateKeyTrimmed !== '') ||
+    (publicKeyAllowed && passphrase != null && passphrase !== '') ||
+    (sshterm != null && sshterm !== '')
   ) {
     const sshOverrides: WebSSH2Config['ssh'] = {
-      host: host || null,
+      host: host != null && host !== '' ? host : null,
       port: sanitizedPort,
-      username: username || null,
+      username: username != null && username !== '' ? username : null,
       password: passwordAllowed && passwordTrimmed ? passwordTrimmed : null,
-      sshterm: sshterm || 'xterm-color'
+      sshterm: sshterm != null && sshterm !== '' ? sshterm : 'xterm-color'
     }
 
     if (!passwordAllowed && passwordTrimmed) {
@@ -207,7 +207,7 @@ export const configWithUrlOverrides = () => {
 
     if (publicKeyAllowed && privateKeyTrimmed) {
       sshOverrides.privateKey = privateKeyTrimmed
-      if (passphrase) {
+      if (passphrase != null && passphrase !== '') {
         sshOverrides.passphrase = passphrase
       }
     } else if (privateKeyTrimmed) {
@@ -220,19 +220,33 @@ export const configWithUrlOverrides = () => {
   const hasAllowedPassword = passwordAllowed && passwordTrimmed.length > 0
   const hasAllowedPrivateKey = publicKeyAllowed && privateKeyTrimmed.length > 0
 
-  if (host && (hasAllowedPassword || hasAllowedPrivateKey)) {
+  if (
+    host != null &&
+    host !== '' &&
+    (hasAllowedPassword || hasAllowedPrivateKey)
+  ) {
     urlOverrides.autoConnect = true
     debug('Auto-connect enabled: host and allowed credentials provided via URL')
-  } else if (host && !password && !privateKey) {
+  } else if (
+    host != null &&
+    host !== '' &&
+    (password == null || password === '') &&
+    (privateKey == null || privateKey === '')
+  ) {
     debug(
       'Auto-connect disabled: host provided but missing credentials (password or privateKey)'
     )
-  } else if (host && (password || privateKey)) {
+  } else if (
+    host != null &&
+    host !== '' &&
+    ((password != null && password !== '') ||
+      (privateKey != null && privateKey !== ''))
+  ) {
     debug(
       'Auto-connect disabled: credentials provided but blocked by server policy',
       {
-        passwordProvided: !!password,
-        privateKeyProvided: !!privateKey
+        passwordProvided: password != null && password !== '',
+        privateKeyProvided: privateKey != null && privateKey !== ''
       }
     )
   }
@@ -240,22 +254,28 @@ export const configWithUrlOverrides = () => {
   const mergedConfig = mergeDeep(baseConfig, urlOverrides) as WebSSH2Config
   const baseAuthPayload: Partial<ClientAuthenticatePayload> = {}
 
-  if (mergedConfig.ssh.host) {
+  if (mergedConfig.ssh.host != null && mergedConfig.ssh.host !== '') {
     baseAuthPayload.host = mergedConfig.ssh.host
   }
   if (typeof mergedConfig.ssh.port === 'number') {
     baseAuthPayload.port = mergedConfig.ssh.port
   }
-  if (mergedConfig.ssh.username) {
+  if (mergedConfig.ssh.username != null && mergedConfig.ssh.username !== '') {
     baseAuthPayload.username = mergedConfig.ssh.username
   }
-  if (mergedConfig.ssh.password) {
+  if (mergedConfig.ssh.password != null && mergedConfig.ssh.password !== '') {
     baseAuthPayload.password = mergedConfig.ssh.password
   }
-  if (mergedConfig.ssh.privateKey) {
+  if (
+    mergedConfig.ssh.privateKey != null &&
+    mergedConfig.ssh.privateKey !== ''
+  ) {
     baseAuthPayload.privateKey = mergedConfig.ssh.privateKey
   }
-  if (mergedConfig.ssh.passphrase) {
+  if (
+    mergedConfig.ssh.passphrase != null &&
+    mergedConfig.ssh.passphrase !== ''
+  ) {
     baseAuthPayload.passphrase = mergedConfig.ssh.passphrase
   }
 
@@ -269,9 +289,11 @@ export const configWithUrlOverrides = () => {
   }
 
   if (
-    urlOverrides.autoConnect &&
-    !sanitizedMergedAuth.password &&
-    !sanitizedMergedAuth.privateKey
+    urlOverrides.autoConnect === true &&
+    (sanitizedMergedAuth.password == null ||
+      sanitizedMergedAuth.password === '') &&
+    (sanitizedMergedAuth.privateKey == null ||
+      sanitizedMergedAuth.privateKey === '')
   ) {
     debug(
       'Auto-connect disabled: sanitized credentials removed disallowed values'
@@ -285,12 +307,13 @@ export const configWithUrlOverrides = () => {
 
 // Initialize configuration from window object and URL
 export function initializeConfig() {
-  const windowConfig =
-    (window as unknown as Record<string, unknown>)['webssh2Config'] || {}
-  const initialConfig = mergeDeep(
-    defaultConfig,
-    windowConfig as Record<string, unknown>
-  ) as WebSSH2Config
+  const rawWindowConfig = (window as unknown as Record<string, unknown>)[
+    'webssh2Config'
+  ]
+  const windowConfig: Record<string, unknown> = isObject(rawWindowConfig)
+    ? rawWindowConfig
+    : {}
+  const initialConfig = mergeDeep(defaultConfig, windowConfig) as WebSSH2Config
 
   const sanitizedConfig: WebSSH2Config = {
     ...initialConfig,
@@ -336,12 +359,12 @@ export const credentials = createRoot(() =>
     }
 
     return {
-      host: cfg.ssh?.host || '',
+      host: cfg.ssh?.host ?? '',
       port,
-      username: cfg.ssh?.username || '',
-      password: cfg.ssh?.password || '',
-      privateKey: cfg.ssh?.privateKey || '',
-      passphrase: cfg.ssh?.passphrase || '',
+      username: cfg.ssh?.username ?? '',
+      password: cfg.ssh?.password ?? '',
+      privateKey: cfg.ssh?.privateKey ?? '',
+      passphrase: cfg.ssh?.passphrase ?? '',
       term: cfg.ssh?.sshterm || 'xterm-color'
     }
   })

--- a/client/src/stores/sftp-store.ts
+++ b/client/src/stores/sftp-store.ts
@@ -547,7 +547,7 @@ function createSftpStoreInternal() {
     ) {
       setState('transfers', (transfer) => transfer.id === transferId, {
         status,
-        ...(error && { error }),
+        ...(error != null && error !== '' ? { error } : {}),
         ...(status === 'completed' && { percentComplete: 100 })
       })
     },

--- a/client/src/utils/clipboard-compatibility.ts
+++ b/client/src/utils/clipboard-compatibility.ts
@@ -1,9 +1,12 @@
 export class ClipboardCompatibility {
   static isSupported(): boolean {
-    return !!(
-      navigator.clipboard &&
-      typeof navigator.clipboard.readText === 'function' &&
-      typeof navigator.clipboard.writeText === 'function'
+    // navigator.clipboard is typed as always present, but is undefined at
+    // runtime in insecure contexts and older browsers.
+    const clipboard: Clipboard | undefined = navigator.clipboard
+    return (
+      clipboard != null &&
+      typeof clipboard.readText === 'function' &&
+      typeof clipboard.writeText === 'function'
     )
   }
 

--- a/client/src/utils/cookies.ts
+++ b/client/src/utils/cookies.ts
@@ -13,7 +13,7 @@ export function getBasicAuthCookie(): string | null {
   const cookies = document.cookie.split(';')
   for (let i = 0; i < cookies.length; i++) {
     let cookie = cookies[i]
-    if (cookie) {
+    if (cookie != null && cookie !== '') {
       while (cookie.charAt(0) === ' ') {
         cookie = cookie.substring(1)
       }

--- a/client/src/utils/debounce.ts
+++ b/client/src/utils/debounce.ts
@@ -17,7 +17,7 @@ export const createDebouncer = <T extends (...args: any[]) => any>(
   let timeoutId: ReturnType<typeof setTimeout> | null = null
 
   return ((...args: Parameters<T>) => {
-    if (timeoutId) {
+    if (timeoutId !== null) {
       clearTimeout(timeoutId)
     }
 
@@ -42,7 +42,7 @@ export const createCancellableDebouncer = <T extends (...args: any[]) => any>(
   let timeoutId: ReturnType<typeof setTimeout> | null = null
 
   const debounced = ((...args: Parameters<T>) => {
-    if (timeoutId) {
+    if (timeoutId !== null) {
       clearTimeout(timeoutId)
     }
 
@@ -53,7 +53,7 @@ export const createCancellableDebouncer = <T extends (...args: any[]) => any>(
   }) as T
 
   const cancel = () => {
-    if (timeoutId) {
+    if (timeoutId !== null) {
       clearTimeout(timeoutId)
       timeoutId = null
     }

--- a/client/src/utils/download-assembler.ts
+++ b/client/src/utils/download-assembler.ts
@@ -384,7 +384,7 @@ export function createDownloadAssembler(
     transferId,
     fileName,
     fileSize,
-    mimeType || 'application/octet-stream',
+    mimeType != null && mimeType !== '' ? mimeType : 'application/octet-stream',
     maxBytes
   )
 }

--- a/client/src/utils/index.ts
+++ b/client/src/utils/index.ts
@@ -65,7 +65,7 @@ export function validateNumber(
 type Obj = Record<string, unknown>
 
 export function isObject(item: unknown): item is Record<string, unknown> {
-  return !!item && typeof item === 'object' && !Array.isArray(item)
+  return item !== null && typeof item === 'object' && !Array.isArray(item)
 }
 
 export function mergeDeep<T, U extends Record<string, unknown>>(
@@ -225,7 +225,7 @@ export function populateFormFromUrl(config: WebSSH2Config): WebSSH2Config {
 
   // Enable autoConnect if host is provided in URL
   const urlHost = searchParams.get('host')
-  if (urlHost && result.ssh) {
+  if (urlHost != null && urlHost !== '') {
     result.autoConnect = true
     debug('populateFormFromUrl: autoConnect enabled due to URL host parameter')
   }
@@ -247,11 +247,22 @@ export function getCredentials(
 
   const fd = formData as Record<string, unknown> | null
 
-  const portValue =
-    (fd?.['port'] as number | string | undefined) ||
-    urlParams.get('port') ||
-    (cfg.ssh?.port as number | undefined) ||
-    '22'
+  const fdPort = fd?.['port'] as number | string | undefined
+  const urlPort = urlParams.get('port')
+  const cfgPort = cfg.ssh?.port as number | undefined
+  let portValue: number | string = '22'
+  if (
+    fdPort != null &&
+    fdPort !== '' &&
+    fdPort !== 0 &&
+    (typeof fdPort === 'string' || !Number.isNaN(fdPort))
+  ) {
+    portValue = fdPort
+  } else if (urlPort != null && urlPort !== '') {
+    portValue = urlPort
+  } else if (cfgPort != null && cfgPort !== 0 && !Number.isNaN(cfgPort)) {
+    portValue = cfgPort
+  }
 
   let port = parseInt(String(portValue), 10)
   if (Number.isNaN(port) || port < 1 || port > 65535) {
@@ -259,47 +270,74 @@ export function getCredentials(
     port = 22
   }
 
+  const fdHost = fd?.['host'] as string | undefined
+  const urlHost = urlParams.get('host')
+  const cfgHost = cfg.ssh?.host as string | undefined
+  let host = ''
+  if (fdHost != null && fdHost !== '') host = fdHost
+  else if (urlHost != null && urlHost !== '') host = urlHost
+  else if (cfgHost != null && cfgHost !== '') host = cfgHost
+
+  const fdUsername = fd?.['username'] as string | undefined
+  const urlUsername = urlParams.get('username')
+  const cfgUsername = cfg.ssh?.username as string | undefined
+  let username = ''
+  if (fdUsername != null && fdUsername !== '') username = fdUsername
+  else if (urlUsername != null && urlUsername !== '') username = urlUsername
+  else if (cfgUsername != null && cfgUsername !== '') username = cfgUsername
+
+  const fdPassword = fd?.['password'] as string | undefined
+  const urlPassword = urlParams.get('password')
+  const cfgPassword = cfg.ssh?.password as string | undefined
+  let password = ''
+  if (fdPassword != null && fdPassword !== '') password = fdPassword
+  else if (urlPassword != null && urlPassword !== '') password = urlPassword
+  else if (cfgPassword != null && cfgPassword !== '') password = cfgPassword
+
+  const fdTerm = fd?.['term'] as string | undefined
+  const urlTerm = urlParams.get('sshterm')
+  const cfgTerm = cfg.ssh?.sshterm as string | undefined
+  let term = 'xterm-color'
+  if (fdTerm != null && fdTerm !== '') term = fdTerm
+  else if (urlTerm != null && urlTerm !== '') term = urlTerm
+  else if (cfgTerm != null && cfgTerm !== '') term = cfgTerm
+
   const mergedConfig: ClientAuthenticatePayload = {
-    host:
-      (fd?.['host'] as string | undefined) ||
-      urlParams.get('host') ||
-      (cfg.ssh?.host as string | undefined) ||
-      '',
+    host,
     port,
-    username:
-      (fd?.['username'] as string | undefined) ||
-      urlParams.get('username') ||
-      (cfg.ssh?.username as string | undefined) ||
-      '',
-    password:
-      (fd?.['password'] as string | undefined) ||
-      urlParams.get('password') ||
-      (cfg.ssh?.password as string | undefined) ||
-      '',
-    term:
-      (fd?.['term'] as string | undefined) ||
-      urlParams.get('sshterm') ||
-      (cfg.ssh?.sshterm as string | undefined) ||
-      'xterm-color'
+    username,
+    password,
+    term
   }
 
-  const privateKey =
-    (fd?.['privateKey'] as string | undefined) ||
-    urlParams.get('privateKey') ||
-    (cfg.ssh?.privateKey as string | undefined) ||
-    ''
-  if (privateKey) {
+  const fdPrivateKey = fd?.['privateKey'] as string | undefined
+  const urlPrivateKey = urlParams.get('privateKey')
+  const cfgPrivateKey = cfg.ssh?.privateKey as string | undefined
+  let privateKey = ''
+  if (fdPrivateKey != null && fdPrivateKey !== '') privateKey = fdPrivateKey
+  else if (urlPrivateKey != null && urlPrivateKey !== '')
+    privateKey = urlPrivateKey
+  else if (cfgPrivateKey != null && cfgPrivateKey !== '')
+    privateKey = cfgPrivateKey
+
+  if (privateKey !== '') {
     mergedConfig.privateKey = privateKey
-    const passphrase =
-      (fd?.['passphrase'] as string | undefined) ||
-      urlParams.get('passphrase') ||
-      (cfg.ssh?.passphrase as string | undefined) ||
-      ''
-    if (passphrase) mergedConfig.passphrase = passphrase
+    const fdPassphrase = fd?.['passphrase'] as string | undefined
+    const urlPassphrase = urlParams.get('passphrase')
+    const cfgPassphrase = cfg.ssh?.passphrase as string | undefined
+    let passphrase = ''
+    if (fdPassphrase != null && fdPassphrase !== '') passphrase = fdPassphrase
+    else if (urlPassphrase != null && urlPassphrase !== '')
+      passphrase = urlPassphrase
+    else if (cfgPassphrase != null && cfgPassphrase !== '')
+      passphrase = cfgPassphrase
+    if (passphrase !== '') mergedConfig.passphrase = passphrase
   }
 
-  if (terminalDimensions.cols) mergedConfig.cols = terminalDimensions.cols
-  if (terminalDimensions.rows) mergedConfig.rows = terminalDimensions.rows
+  if (terminalDimensions.cols != null && terminalDimensions.cols !== 0)
+    mergedConfig.cols = terminalDimensions.cols
+  if (terminalDimensions.rows != null && terminalDimensions.rows !== 0)
+    mergedConfig.rows = terminalDimensions.rows
 
   const maskedContent = maskObject(mergedConfig)
   debug('getCredentials: mergedConfig:', maskedContent)
@@ -399,8 +437,9 @@ export function validatePrivateKeyDeep(
   ]
   for (const { type, re } of patterns) {
     const m = text.match(re)
-    if (m && m.groups && m.groups['body']) {
-      blocks.push({ type, body: m.groups['body'] })
+    const matchedBody = m?.groups?.['body']
+    if (matchedBody != null && matchedBody !== '') {
+      blocks.push({ type, body: matchedBody })
       break
     }
   }
@@ -416,7 +455,7 @@ export function validatePrivateKeyDeep(
       for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
     } else if (
       typeof globalThis !== 'undefined' &&
-      (globalThis as Record<string, unknown>)['Buffer']
+      (globalThis as Record<string, unknown>)['Buffer'] != null
     ) {
       const B = (
         globalThis as unknown as {

--- a/client/src/utils/input-validator.ts
+++ b/client/src/utils/input-validator.ts
@@ -27,7 +27,7 @@ export const MAX_LENGTHS = {
  * Validates and sanitizes a hostname
  */
 export function validateHost(host: unknown): string | null {
-  if (!host || typeof host !== 'string') return null
+  if (typeof host !== 'string' || host === '') return null
 
   let value = host
   // Remove any protocol prefixes
@@ -68,7 +68,7 @@ export function validatePort(port: unknown): number | null {
 
 /** Validates and sanitizes a username */
 export function validateUsername(username: unknown): string | null {
-  if (!username || typeof username !== 'string') return null
+  if (typeof username !== 'string' || username === '') return null
   const value = username.trim()
   if (value.length === 0 || value.length > MAX_LENGTHS.username) {
     debug('Invalid username length:', value.length)
@@ -97,7 +97,7 @@ export function validateText(
   text: unknown,
   maxLength: number = MAX_LENGTHS.header
 ): string {
-  if (!text || typeof text !== 'string') return ''
+  if (typeof text !== 'string' || text === '') return ''
   let value = text
   if (value.length > maxLength) {
     debug('Text truncated from', value.length, 'to', maxLength)
@@ -108,7 +108,7 @@ export function validateText(
 
 /** Validates a color value */
 export function validateColor(color: unknown): string | null {
-  if (!color || typeof color !== 'string') return null
+  if (typeof color !== 'string' || color === '') return null
   const value = color.trim()
   if (value.length > MAX_LENGTHS.headerbackground) return null
   const hexRegex = /^#([0-9a-fA-F]{3}){1,2}$/
@@ -127,7 +127,7 @@ export function validateColor(color: unknown): string | null {
 
 /** Validates terminal type */
 export function validateTerminalType(term: unknown): string | null {
-  if (!term || typeof term !== 'string') return null
+  if (typeof term !== 'string' || term === '') return null
   const value = term.trim()
   if (value.length === 0 || value.length > MAX_LENGTHS.sshterm) return null
   const validTermTypes = [
@@ -156,7 +156,7 @@ export function validateTerminalType(term: unknown): string | null {
 
 /** Validates log level */
 export function validateLogLevel(level: unknown): string | null {
-  if (!level || typeof level !== 'string') return null
+  if (typeof level !== 'string' || level === '') return null
   const value = level.trim().toLowerCase()
   const validLevels = ['error', 'warn', 'info', 'debug', 'trace', 'silent']
   if (validLevels.includes(value)) return value
@@ -176,49 +176,66 @@ export function validateUrlParameters(params: URLSearchParams) {
     logLevel: null as string | null
   }
   const host = params.get('host')
-  if (host) validated.host = validateHost(host)
+  if (host != null && host !== '') validated.host = validateHost(host)
   const port = params.get('port')
-  if (port) {
+  if (port != null && port !== '') {
     const validPort = validatePort(port)
-    if (validPort) validated.port = validPort
+    // validatePort only returns numbers in 1-65535, so a null check suffices
+    if (validPort != null) validated.port = validPort
   }
   const username = params.get('username')
-  if (username) validated.username = validateUsername(username)
+  if (username != null && username !== '') {
+    validated.username = validateUsername(username)
+  }
   const password = params.get('password')
-  if (password) validated.password = validatePassword(password)
+  if (password != null && password !== '') {
+    validated.password = validatePassword(password)
+  }
   const header = params.get('header')
-  if (header) validated.header.text = validateText(header)
+  if (header != null && header !== '')
+    validated.header.text = validateText(header)
   const headerBg = params.get('headerbackground')
-  if (headerBg) validated.header.background = validateColor(headerBg)
+  if (headerBg != null && headerBg !== '') {
+    validated.header.background = validateColor(headerBg)
+  }
   const term = params.get('sshterm')
-  if (term) validated.sshterm = validateTerminalType(term)
+  if (term != null && term !== '')
+    validated.sshterm = validateTerminalType(term)
   const logLevel = params.get('logLevel')
-  if (logLevel) validated.logLevel = validateLogLevel(logLevel)
+  if (logLevel != null && logLevel !== '') {
+    validated.logLevel = validateLogLevel(logLevel)
+  }
   debug('Validated URL parameters:', validated)
   return validated
 }
 
 /** Validates form data before submission */
 export function validateFormData(formData: unknown) {
-  if (!formData || typeof formData !== 'object') return null
+  if (formData == null || typeof formData !== 'object') return null
   const fd = formData as Record<string, unknown>
   const validated: Record<string, unknown> = {}
 
-  if (!fd['host'] || !validateHost(fd['host'])) {
+  // validateHost returns null for every non-string or empty input, so a
+  // single null check covers the previous missing-value short-circuit
+  const validHost = validateHost(fd['host'])
+  if (validHost == null) {
     debug('Invalid or missing host')
     return null
   }
-  validated['host'] = validateHost(fd['host'])
+  validated['host'] = validHost
 
-  if (!fd['username'] || !validateUsername(fd['username'])) {
+  // validateUsername likewise returns null for non-string or empty input
+  const validUsername = validateUsername(fd['username'])
+  if (validUsername == null) {
     debug('Invalid or missing username')
     return null
   }
-  validated['username'] = validateUsername(fd['username'])
+  validated['username'] = validUsername
 
   if (fd['port'] !== undefined) {
     const port = validatePort(fd['port'])
-    if (!port) {
+    // validatePort only returns numbers in 1-65535, so a null check suffices
+    if (port == null) {
       debug('Invalid port')
       return null
     }
@@ -227,22 +244,25 @@ export function validateFormData(formData: unknown) {
     validated['port'] = 22
   }
 
-  if (fd['password']) validated['password'] = validatePassword(fd['password'])
-  if (fd['privateKey']) {
-    const pk = String(fd['privateKey'])
-    if (pk.length > MAX_LENGTHS.privateKey) {
+  const passwordValue = fd['password']
+  if (typeof passwordValue === 'string' && passwordValue !== '') {
+    validated['password'] = validatePassword(passwordValue)
+  }
+  const privateKeyValue = fd['privateKey']
+  if (typeof privateKeyValue === 'string' && privateKeyValue !== '') {
+    if (privateKeyValue.length > MAX_LENGTHS.privateKey) {
       debug('Private key too large')
       return null
     }
-    validated['privateKey'] = pk
+    validated['privateKey'] = privateKeyValue
   }
-  if (fd['passphrase']) {
-    const pp = String(fd['passphrase'])
-    if (pp.length > MAX_LENGTHS.passphrase) {
+  const passphraseValue = fd['passphrase']
+  if (typeof passphraseValue === 'string' && passphraseValue !== '') {
+    if (passphraseValue.length > MAX_LENGTHS.passphrase) {
       debug('Passphrase too long')
       return null
     }
-    validated['passphrase'] = pp
+    validated['passphrase'] = passphraseValue
   }
   return validated
 }

--- a/client/src/utils/keyboard-capture.ts
+++ b/client/src/utils/keyboard-capture.ts
@@ -133,8 +133,11 @@ export function shouldCaptureKey(
   }
 
   // Check custom capture keys
-  if (settings.customCaptureKeys && settings.customCaptureKeys.length > 0) {
-    for (const keyString of settings.customCaptureKeys) {
+  // Settings may originate from stored/external config where the array is
+  // absent despite the type, so keep a defensive runtime check.
+  const customCaptureKeys: string[] | undefined = settings.customCaptureKeys
+  if (customCaptureKeys != null && customCaptureKeys.length > 0) {
+    for (const keyString of customCaptureKeys) {
       const parsed = parseKeyString(keyString)
       if (parsed && matchesKeyString(event, parsed)) {
         debug(`Capturing custom key "${keyString}" for terminal`)

--- a/client/src/utils/os-detection.ts
+++ b/client/src/utils/os-detection.ts
@@ -7,7 +7,7 @@ export interface KeyboardShortcut {
 }
 
 const getOS = (): OSType => {
-  if (typeof window === 'undefined' || !window.navigator) {
+  if (typeof window === 'undefined' || window.navigator == null) {
     return 'Unknown'
   }
 

--- a/client/src/utils/validation.ts
+++ b/client/src/utils/validation.ts
@@ -61,12 +61,18 @@ export const ValidationRules = {
   }),
 
   minLength: (min: number, message?: string): ValidationRule<string> => ({
-    message: message || `Must be at least ${min} characters`,
+    message:
+      message != null && message !== ''
+        ? message
+        : `Must be at least ${min} characters`,
     validate: (value) => value.length >= min
   }),
 
   maxLength: (max: number, message?: string): ValidationRule<string> => ({
-    message: message || `Must be no more than ${max} characters`,
+    message:
+      message != null && message !== ''
+        ? message
+        : `Must be no more than ${max} characters`,
     validate: (value) => value.length <= max
   }),
 
@@ -219,7 +225,7 @@ export function createAsyncValidator<T>(
     return new Promise((resolve) => {
       setIsValidating(true)
 
-      if (timeoutId) {
+      if (timeoutId !== undefined) {
         clearTimeout(timeoutId)
       }
 
@@ -248,7 +254,7 @@ export function createAsyncValidator<T>(
     isValidating,
     validate,
     reset: () => {
-      if (timeoutId) {
+      if (timeoutId !== undefined) {
         clearTimeout(timeoutId)
       }
       setValidation({ isValid: true })


### PR DESCRIPTION
Closes #118.

Completes the SC7 follow-up from the 2026-06-10 red-team review: enables `@typescript-eslint/strict-boolean-expressions` in the type-aware `client/src` ESLint override and burns down all violations (214 at time of fix; 218 when the issue was filed), then ratchets the rule to **error** to match the `no-unsafe-*` rules and org policy.

## Approach

The issue's warn → burndown → error staging is collapsed into one PR (three commits preserve the stages). Default rule options are kept — `allowNullableString` etc. would exempt the dominant violation class (146 of 214 are nullable-string truthiness), which is exactly what the policy wants made explicit.

## Fix conventions (behavior-preserving)

- Nullable strings: `if (s)` → `s != null && s !== ''`
- Nullable booleans: `=== true` / `!== true`
- Nullable numbers: `!= null && !== 0` (NaN guards where the original `||` falsiness mattered)
- `||` fallbacks keep empty-string semantics via explicit ternaries; `??` only where provably equivalent (fallback is `''` or value can never be `''`)
- `any` conditionals: proper `typeof` narrowing instead of casts
- Always-true object checks: removed when provably dead per types and call sites, or the local type corrected where the value genuinely can be absent at runtime (`navigator.clipboard` in insecure contexts; xterm-solid addon/event managers before mount)

No `eslint-disable` comments were added anywhere.

## Notable changes beyond pure mechanics

- `utils/input-validator.ts`: redundant truthiness pre-checks in `validateFormData` collapsed into the validators' own fail-closed null returns (verified `validateHost`/`validateUsername` reject non-string/empty). Truthy **non-string** credential values are now skipped instead of `String()`-coerced — strictly safer.
- `services/socket.ts`: any-typed `data.name` now requires `typeof === 'string'`, dropping an unsound `as string` cast.
- Dead checks removed: `actions.clipboard` (app.tsx), `fitAddonInstance` (Terminal.tsx), two required-prop guards (LoginModal/Modal), `onSearchResults` (TerminalSearch.tsx).
- `lib/xterm-solid/components/XTerm.tsx`: `addonManager`/`eventManager` typed `| undefined` to match their mount lifecycle (existing guards were already written as if nullable).

## Verification

- `npx eslint client/src --ext .ts,.tsx` with the rule at **error**: 0 problems
- `npm run check:all`: lint, stylelint, prettier, html-validate, both typechecks, and all 318 tests pass
- `npm run build`: production bundle compiles