### PR TITLE
ci: pin GitHub Actions to exact released versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -47,7 +47,7 @@ jobs:
         run: npm audit --audit-level=high
 
       - name: Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # v0.34.2
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -57,7 +57,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3
+        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -68,10 +68,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@46a3c492319c890177366b6ef46d6b4f89743ed4 # v4
+        uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Release Please
         id: release
-        uses: googleapis/release-please-action@c3fc4de07084f75a2b61a5b933069bda6edf3d5c # v4
+        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tag
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -49,7 +49,7 @@ jobs:
         run: npm run build:server
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: build-output
           path: |
@@ -65,7 +65,7 @@ jobs:
       contents: write
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: build-output
 
@@ -76,7 +76,7 @@ jobs:
           cd -
 
       - name: Attach assets to release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
           files: |
@@ -93,19 +93,19 @@ jobs:
       contents: read
     steps:
       - name: Checkout tag
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Download build artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: build-output
 

--- a/.github/workflows/update-webssh2-dependency.yml
+++ b/.github/workflows/update-webssh2-dependency.yml
@@ -15,20 +15,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout webssh2_client
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: billchurch/webssh2_client
           path: webssh2_client
 
       - name: Checkout webssh2
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: billchurch/webssh2
           token: ${{ secrets.GITHUB_TOKEN }}
           path: webssh2
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
 
@@ -72,7 +72,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check-changes.outputs.has-changes == 'true'
-        uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412 # v7
+        uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412 # v7.0.9
         with:
           path: webssh2
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Updates every GitHub Actions pin comment from a bare major (`# v5`, `# v4`) to the exact released version, so a reviewer can confirm each pinned SHA corresponds to a specific published release.

Closes #116

## Verification findings (verify-on-touch)

Every SHA was checked against the action repo's tags via the GitHub API. Most pins were fine and only needed their comment corrected:

| Action | SHA (unchanged) | Comment |
| --- | --- | --- |
| actions/checkout | `93cb6ef` | `# v5` → `# v5.0.1` |
| actions/setup-node | `49933ea` | `# v4` → `# v4.4.0` |
| github/codeql-action/upload-sarif | `ff0a06e` | `# v3` → `# v3.28.18` |
| actions/upload-artifact | `ea165f8` | `# v4` → `# v4.6.2` |
| actions/download-artifact | `d3f86a1` | `# v4` → `# v4.3.0` |
| softprops/action-gh-release | `a06a81a` | `# v2` → `# v2.5.0` |
| peter-evans/create-pull-request | `84ae59a` | `# v7` → `# v7.0.9` |

Three pins did **not** correspond to a release commit and were repinned:

| Action | Problem | Fix |
| --- | --- | --- |
| aquasecurity/trivy-action | Pinned to untagged master commit `97e0b38`; comment claimed `v0.34.2`, which doesn't exist | Repinned to `ed142fd` = v0.36.0 (published 2026-04-22, past the 14-day quarantine) |
| actions/dependency-review-action | `46a3c49` is the annotated tag *object* of the mutable `v4` tag, not a commit | Repinned to the commit it dereferences to: `3c4e3dc` = v4.8.2 |
| googleapis/release-please-action | `c3fc4de` is the annotated tag *object* of the mutable `v4` tag | Repinned to the commit it dereferences to: `16a9c90` = v4.4.0 |

For the two tag-object pins the effective code is unchanged — the new SHAs are the exact commits those tag objects pointed to. Trivy-action moves from an arbitrary March master snapshot to the v0.36.0 release.

## Test plan

- [x] All ten SHAs verified against their repos' tags/releases via `gh api`
- [ ] CI green on this PR (exercises checkout, setup-node, trivy, upload-sarif, dependency-review directly)