### PR TITLE
fix(security): CSP readiness — JSON config block + fix dead csp-config.ts docs

### DIFF
--- a/DOCS/SECURITY.md
+++ b/DOCS/SECURITY.md
@@ -10,12 +10,22 @@ This document summarizes the client-side security measures in this repository an
 
 ## Content Security Policy (CSP)
 
-The app serves a strict CSP via `client/src/js/csp-config.ts`:
+The client does not serve a CSP itself — the `Content-Security-Policy`
+response header is owned by the webssh2 gateway that serves these assets.
+The client is kept compatible with a strict policy:
 
-- `script-src 'self'`: Disallows inline scripts. Our HTML contains no inline scripts.
-- `style-src 'self' 'unsafe-inline'`: Allows inline styles required by xterm DOM renderer and small style updates (e.g., banner color). No untrusted CSS is injected.
-- `connect-src 'self' ws: wss:`: Allows WebSocket traffic to the current host. In production, consider pinning the exact origin and path (e.g., only `/ssh/socket.io`).
-- Other directives: Disallow frames/objects; set safe defaults for fonts, images, referrer policy, and permissions policy.
+- `script-src 'self'` compatible: Runtime config is injected by the gateway
+  into an inert `<script type="application/json" id="webssh2-config">` data
+  block, read by `client/src/utils/injected-config.ts`. A legacy inline
+  `window.webssh2Config = null;` script remains for older gateways; under a
+  strict policy it is blocked harmlessly and the JSON block takes over. No
+  `eval()` or string-based timers are used.
+- `style-src 'self' 'unsafe-inline'` required: xterm.js sets inline style
+  attributes, so inline styles must be allowed. No untrusted CSS is injected.
+- `connect-src`: Should be pinned to the gateway origin (e.g., only
+  `/ssh/socket.io`) to limit exfiltration channels.
+- Other directives (frames/objects/fonts/images, report-only rollout) are a
+  gateway concern.
 
 ## xterm.js Considerations
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,19 @@ localStorage.setItem('webssh2.settings.global', JSON.stringify(settings))
 
 ### Configuration Object
 
-You can configure the client by setting `window.webssh2Config`:
+The preferred, CSP-compatible way to configure the client is the inert JSON
+data block in the served HTML, which the app reads at startup:
+
+```html
+<script type="application/json" id="webssh2-config">
+  { "socket": { "path": "/ssh/socket.io" }, "ssh": { "port": 22 } }
+</script>
+```
+
+Setting `window.webssh2Config` from an inline script is still supported for
+backward compatibility, but a strict `script-src` CSP will block inline
+scripts, so new integrations should use the JSON block. When both are
+present, the JSON block wins:
 
 ```javascript
 window.webssh2Config = {

--- a/client/src/client.htm
+++ b/client/src/client.htm
@@ -7,9 +7,10 @@
     <title>WebSSH2</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content">
     <link rel="icon" type="image/x-icon" href="favicon.ico">
-    <script>
-      window.webssh2Config = <%= htmlWebpackPlugin.options.webssh2Config %>;
-    </script>
+    <!-- CSP-compatible config injection point: inert JSON data block read by the app -->
+    <script type="application/json" id="webssh2-config">null</script>
+    <!-- Legacy config injection point: superseded by the JSON block above; kept for older gateways -->
+    <script>window.webssh2Config = null;</script>
   </head>
   <body class="h-dvh overflow-hidden bg-black text-neutral-100">
     <dialog id="loginDialog" class="modal">

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -14,9 +14,10 @@
         color: #f5f5f5 !important;
       }
     </style>
-    <script>
-      window.webssh2Config = <%= htmlWebpackPlugin.options.webssh2Config %>;
-    </script>
+    <!-- CSP-compatible config injection point: inert JSON data block read by the app -->
+    <script type="application/json" id="webssh2-config">null</script>
+    <!-- Legacy config injection point: superseded by the JSON block above; kept for older gateways -->
+    <script>window.webssh2Config = null;</script>
     <script type="module" src="./index.tsx"></script>
   </head>
   <body class="h-dvh overflow-hidden bg-black text-neutral-100">

--- a/client/src/stores/config.ts
+++ b/client/src/stores/config.ts
@@ -3,6 +3,7 @@ import { createSignal, createMemo, createRoot } from 'solid-js'
 import createDebug from 'debug'
 import maskObject from 'jsmasker'
 import { isObject, mergeDeep } from '../utils/index.js'
+import { readInjectedConfig } from '../utils/injected-config.js'
 import { DEFAULT_AUTH_METHODS } from '../constants.js'
 import type {
   ClientThemingConfig,
@@ -305,11 +306,9 @@ export const configWithUrlOverrides = () => {
   return mergedConfig
 }
 
-// Initialize configuration from window object and URL
+// Initialize configuration from injected config (JSON block or window) and URL
 export function initializeConfig() {
-  const rawWindowConfig = (window as unknown as Record<string, unknown>)[
-    'webssh2Config'
-  ]
+  const rawWindowConfig: unknown = readInjectedConfig()
   const windowConfig: Record<string, unknown> = isObject(rawWindowConfig)
     ? rawWindowConfig
     : {}

--- a/client/src/utils/index.ts
+++ b/client/src/utils/index.ts
@@ -13,6 +13,8 @@ import {
   validateLogLevel
 } from './input-validator.js'
 
+import { readInjectedConfig } from './injected-config.js'
+
 import type { TerminalSettings, WebSSH2Config } from '../types/config.d'
 import type { ClientAuthenticatePayload } from '../types/events.d'
 
@@ -130,7 +132,7 @@ export function initializeConfig(): WebSSH2Config {
     autoConnect: false,
     logLevel: 'info'
   }
-  const userConfig = (window as Window).webssh2Config || {}
+  const userConfig: Partial<WebSSH2Config> = readInjectedConfig() ?? {}
   const config = mergeDeep(
     defaultConfig,
     userConfig as Partial<WebSSH2Config>
@@ -242,7 +244,7 @@ export function getCredentials(
   formData: Record<string, unknown> | null = null,
   terminalDimensions: { cols?: number; rows?: number } = {}
 ): ClientAuthenticatePayload {
-  const cfg = (window as Window).webssh2Config || {}
+  const cfg: Partial<WebSSH2Config> = readInjectedConfig() ?? {}
   const urlParams = getUrlParams()
 
   const fd = formData as Record<string, unknown> | null

--- a/client/src/utils/injected-config.ts
+++ b/client/src/utils/injected-config.ts
@@ -1,0 +1,62 @@
+// client/src/utils/injected-config.ts
+// CSP-compatible runtime config reader.
+//
+// The webssh2 gateway injects runtime config into the served HTML. The
+// CSP-compatible injection point is a JSON data block:
+//
+//   <script type="application/json" id="webssh2-config">{...}</script>
+//
+// which is inert (never executed), so it survives a strict
+// `script-src 'self'` policy. Gateways that predate the data block still
+// replace the legacy inline `window.webssh2Config = null;` script, so the
+// reader falls back to the window global when the block is absent or
+// still holds its `null` placeholder.
+
+import type { WebSSH2Config } from '../types/config.d'
+
+const CONFIG_BLOCK_ID = 'webssh2-config'
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function readConfigBlock(): Partial<WebSSH2Config> | undefined {
+  const element = document.getElementById(CONFIG_BLOCK_ID)
+  if (element === null) {
+    return undefined
+  }
+  if (element.getAttribute('type') !== 'application/json') {
+    return undefined
+  }
+  const text = element.textContent
+  if (text === null || text.trim() === '') {
+    return undefined
+  }
+  try {
+    const parsed: unknown = JSON.parse(text)
+    if (isPlainObject(parsed)) {
+      return parsed as Partial<WebSSH2Config>
+    }
+  } catch {
+    console.warn('webssh2-config block contains invalid JSON; ignoring it')
+  }
+  return undefined
+}
+
+/**
+ * Read the gateway-injected runtime config.
+ *
+ * Prefers the `<script type="application/json" id="webssh2-config">` data
+ * block; falls back to the legacy `window.webssh2Config` global. Returns
+ * `undefined` when neither source provides a config object.
+ */
+export function readInjectedConfig(): Partial<WebSSH2Config> | undefined {
+  const fromBlock = readConfigBlock()
+  if (fromBlock !== undefined) {
+    return fromBlock
+  }
+  const fromWindow: unknown = window.webssh2Config
+  return isPlainObject(fromWindow)
+    ? (fromWindow as Partial<WebSSH2Config>)
+    : undefined
+}

--- a/client/src/vite.config.js
+++ b/client/src/vite.config.js
@@ -74,17 +74,20 @@ function htmlTemplatePlugin() {
         `<!-- Version ${bannerString} -->`
       )
 
-      const webssh2Config = isDevelopment
-        ? JSON.stringify({
-            socket: { url: 'http://localhost:2222', path: '/ssh/socket.io' },
-            ssh: { port: 22 }
-          })
-        : 'null'
+      // In development, inject dev config into the JSON data block so the
+      // CSP-compatible read path is exercised. In production both injection
+      // points keep their `null` placeholders for the gateway to replace.
+      if (isDevelopment) {
+        const webssh2Config = JSON.stringify({
+          socket: { url: 'http://localhost:2222', path: '/ssh/socket.io' },
+          ssh: { port: 22 }
+        })
 
-      html = html.replace(
-        'window.webssh2Config = <%= htmlWebpackPlugin.options.webssh2Config %>;',
-        `window.webssh2Config = ${webssh2Config};`
-      )
+        html = html.replace(
+          '<script type="application/json" id="webssh2-config">null</script>',
+          `<script type="application/json" id="webssh2-config">${webssh2Config}</script>`
+        )
+      }
 
       return html
     }

--- a/tests/injected-config.test.js
+++ b/tests/injected-config.test.js
@@ -1,0 +1,107 @@
+/**
+ * Tests for the CSP-compatible runtime config reader.
+ *
+ * Runtime config is injected by the webssh2 gateway. The CSP-compatible
+ * path is a `<script type="application/json" id="webssh2-config">` data
+ * block; the legacy path is an inline script assigning
+ * `window.webssh2Config`. The reader must prefer the JSON block and fall
+ * back to the window global so the client keeps working with gateways
+ * that still use the legacy placeholder.
+ */
+
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { pathToFileURL } from 'node:url'
+import { JSDOM } from 'jsdom'
+
+await register('./tests/ts-loader.mjs', pathToFileURL('./'))
+
+const dom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>')
+globalThis.window = dom.window
+globalThis.document = dom.window.document
+
+const { readInjectedConfig } =
+  await import('../client/src/utils/injected-config.ts')
+
+const setConfigBlock = (content, { type = 'application/json' } = {}) => {
+  const script = dom.window.document.createElement('script')
+  if (type !== null) {
+    script.setAttribute('type', type)
+  }
+  script.setAttribute('id', 'webssh2-config')
+  script.textContent = content
+  dom.window.document.head.appendChild(script)
+  return script
+}
+
+describe('readInjectedConfig', () => {
+  beforeEach(() => {
+    delete dom.window.webssh2Config
+    const existing = dom.window.document.getElementById('webssh2-config')
+    if (existing) {
+      existing.remove()
+    }
+  })
+
+  it('reads config from the JSON data block', () => {
+    setConfigBlock(
+      '{"socket":{"url":"http://gw:2222","path":"/ssh/socket.io"}}'
+    )
+    assert.deepStrictEqual(readInjectedConfig(), {
+      socket: { url: 'http://gw:2222', path: '/ssh/socket.io' }
+    })
+  })
+
+  it('prefers the JSON block over window.webssh2Config', () => {
+    setConfigBlock('{"ssh":{"port":2022}}')
+    dom.window.webssh2Config = { ssh: { port: 22 } }
+    assert.deepStrictEqual(readInjectedConfig(), { ssh: { port: 2022 } })
+  })
+
+  it('falls back to window.webssh2Config when the block is absent', () => {
+    dom.window.webssh2Config = { ssh: { port: 2222 } }
+    assert.deepStrictEqual(readInjectedConfig(), { ssh: { port: 2222 } })
+  })
+
+  it('falls back when the block holds the unreplaced "null" placeholder', () => {
+    setConfigBlock('null')
+    dom.window.webssh2Config = { autoConnect: true }
+    assert.deepStrictEqual(readInjectedConfig(), { autoConnect: true })
+  })
+
+  it('falls back on malformed JSON', () => {
+    setConfigBlock('{not json!')
+    dom.window.webssh2Config = { logLevel: 'debug' }
+    assert.deepStrictEqual(readInjectedConfig(), { logLevel: 'debug' })
+  })
+
+  it('falls back when the block parses to a non-object', () => {
+    setConfigBlock('"just a string"')
+    dom.window.webssh2Config = { logLevel: 'info' }
+    assert.deepStrictEqual(readInjectedConfig(), { logLevel: 'info' })
+  })
+
+  it('falls back when the block parses to an array', () => {
+    setConfigBlock('[1,2,3]')
+    dom.window.webssh2Config = { logLevel: 'info' }
+    assert.deepStrictEqual(readInjectedConfig(), { logLevel: 'info' })
+  })
+
+  it('ignores an element whose type is not application/json', () => {
+    setConfigBlock('{"ssh":{"port":2022}}', { type: 'text/plain' })
+    dom.window.webssh2Config = { ssh: { port: 22 } }
+    assert.deepStrictEqual(readInjectedConfig(), { ssh: { port: 22 } })
+  })
+
+  it('returns undefined when neither source is present', () => {
+    assert.strictEqual(readInjectedConfig(), undefined)
+  })
+
+  it('parses script-safe escaped JSON (\\u003c) from the block', () => {
+    setConfigBlock('{"header":{"text":"\\u003cwelcome\\u003e"}}')
+    assert.deepStrictEqual(readInjectedConfig(), {
+      header: { text: '<welcome>' }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Client-side CSP readiness per #117: makes runtime config injection compatible with a strict `script-src` policy and removes misleading documentation that referenced a nonexistent `csp-config.ts`.

Closes #117

## Changes

### CSP-compatible config injection

- Both HTML templates now carry an inert JSON data block as the primary injection point, alongside the legacy inline script:

  ```html
  <script type="application/json" id="webssh2-config">null</script>
  <script>window.webssh2Config = null;</script>
  ```

- New `client/src/utils/injected-config.ts` exports `readInjectedConfig()`, which parses the JSON block (only accepting a non-null, non-array object; tolerating the unreplaced `null` placeholder and malformed JSON) and falls back to `window.webssh2Config`. When both are present the JSON block wins.
- `stores/config.ts` and `utils/index.ts` (`initializeConfig`, `getCredentials`) now read config through it.
- Vite dev server injects the dev config into the JSON block, so development exercises the new read path.

### Backward/forward compatibility

- The built `client.htm` still contains the exact `window.webssh2Config = null;` string, so current webssh2 gateways (`app/utils/html-transformer.ts` string replacement) keep working unchanged via the fallback path.
- A future gateway can inject into the JSON block instead and ship `script-src 'self'`/nonce CSP; the blocked legacy inline script is then harmless.

### Documentation

- `DOCS/SECURITY.md`: CSP section rewritten — the client does not (and never did) serve a CSP; the header is the webssh2 gateway's responsibility, and the client's job is to stay strict-CSP compatible. Dead `csp-config.ts` reference removed.
- `README.md`: documents the JSON block as the preferred configuration mechanism.

### Not included

- The actual `Content-Security-Policy` header (helmet, nonce, `frame-ancestors`, report-only rollout) is out of scope — tracked in the webssh2 gateway repo per the issue.

## Test plan

- [x] New `tests/injected-config.test.js` — 10 cases: block parsing, block-over-window precedence, fallback on absent block / `null` placeholder / malformed JSON / non-object / wrong `type` attribute, script-safe `<` escapes
- [x] `npm run check:all` — lint, format, typecheck, 328/328 tests pass
- [x] `npm run build` — built `client.htm` verified to contain both the JSON block and the byte-exact legacy placeholder the gateway replaces