### PR TITLE
fix(security): harden release pipeline integrity (SC2/SC3/SC4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build client
         run: npm run build
@@ -75,12 +75,37 @@ jobs:
           zip -r ../../client-public.zip .
           cd -
 
+      - name: Generate checksums
+        env:
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          {
+            echo "# webssh2_client ${TAG_NAME} SHA-256 checksums"
+            sha256sum client-public.zip
+            cd client && find public -type f | LC_ALL=C sort | xargs sha256sum
+          } > checksums.txt
+          cat checksums.txt
+          {
+            echo '## Artifact checksums (SHA-256)'
+            echo ''
+            echo 'Per-file hashes of the shipped browser bundle. Verify against'
+            echo 'the npm-installed package or the attached zip; see SECURITY'
+            echo 'docs ("Release artifact integrity") for how.'
+            echo ''
+            echo '```text'
+            cat checksums.txt
+            echo '```'
+          } > checksums-notes.md
+
       - name: Attach assets to release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
           files: |
             client-public.zip
+            checksums.txt
+          append_body: true
+          body_path: checksums-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update-webssh2-dependency.yml
+++ b/.github/workflows/update-webssh2-dependency.yml
@@ -55,7 +55,7 @@ jobs:
           npm pkg set dependencies.webssh2_client="^${{ steps.get-version.outputs.version }}"
           
           # Run npm install to update package-lock.json
-          npm install
+          npm install --ignore-scripts
 
       - name: Check for changes
         id: check-changes

--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,8 @@ Thumbs.db
 *.temp
 
 # Runtime configuration
-.npmrc
+# NOTE: .npmrc is intentionally tracked (tag-signing config only).
+# Never put registry tokens in it - publishing uses OIDC provenance.
 .yarnrc
 
 # Optional npm cache directory

--- a/DOCS/SECURITY.md
+++ b/DOCS/SECURITY.md
@@ -48,6 +48,45 @@ The client is kept compatible with a strict policy:
   - CI-amenable rules enforce safe patterns and flag risky constructs.
 - Tests: JSDOM-based tests focus on XSS and DOM safety.
 
+## Release Artifact Integrity
+
+The npm package ships a pre-built browser bundle (`client/public/**`) that is
+not committed to git, so its integrity rests on the release pipeline. The
+following controls apply (red-team review 2026-06-10, SC2/SC4):
+
+- **No lifecycle scripts at build time:** CI and the release build both
+  install with `npm ci --ignore-scripts`, so no transitive dependency can run
+  code on the build runner and tamper with the bundle before it is published.
+- **npm provenance:** Releases are published with
+  `npm publish --provenance` via OIDC (no long-lived npm tokens). Consumers
+  can verify with:
+
+```bash
+npm audit signatures
+```
+
+- **Published checksums:** Each GitHub release attaches `checksums.txt`
+  (SHA-256 of `client-public.zip` and every file in `client/public/`) and
+  repeats the hashes in the release notes. To verify an npm-installed copy
+  against the GitHub release:
+
+```bash
+cd node_modules/webssh2_client/client
+curl -fsSL "https://github.com/billchurch/webssh2_client/releases/download/<tag>/checksums.txt" \
+  | grep '^[0-9a-f]*  public/' | sha256sum -c -
+```
+
+A mismatch means the npm artifact and the GitHub release disagree — treat
+as a compromise indicator until explained. Note that release assets and
+notes are mutable by anyone with repo write access; the tamper-evident
+anchor is npm provenance, and the checksums exist to make cross-channel
+comparison practical.
+
+- **Reproducible banner:** The bundle banner embeds the git commit date
+  (not the build time), so rebuilding the same tag yields comparable output.
+- **`.npmrc`:** Intentionally committed and limited to `sign-git-tag=true`.
+  Never add registry tokens to it; publishing uses OIDC.
+
 ## Operational Guidance
 
 - HTTPS recommended: Use `wss:` in production.

--- a/client/src/vite.config.js
+++ b/client/src/vite.config.js
@@ -14,8 +14,12 @@ const packageJson = JSON.parse(fs.readFileSync('../../package.json', 'utf-8'))
 // Get git commit hash
 const commitHash = execSync('git rev-parse --short HEAD').toString().trim()
 
+// Commit date, not build time: keeps the build reproducible so the
+// published bundle can be byte-compared against a rebuild of the tag.
+const commitDate = execSync('git log -1 --format=%cI').toString().trim()
+
 // Generate banner string
-const bannerString = `Version ${packageJson.version} - ${new Date().toISOString()} - ${commitHash}`
+const bannerString = `Version ${packageJson.version} - ${commitDate} - ${commitHash}`
 
 // Custom plugin to inject banner into files
 function bannerPlugin() {


### PR DESCRIPTION
## Summary

Implements the supply-chain cluster (SC2, SC3, SC4) from the 2026-06-10 red-team review in a single PR.

## SC4 — no lifecycle scripts in release builds

The release `build` job (which produces the published artifact) ran plain `npm ci`, letting any transitive dependency's `postinstall` execute on the release runner and potentially tamper with the bundle *before* it gets published with provenance — laundering the tampered bytes through the attestation. Now:

- `release.yml` build job: `npm ci --ignore-scripts`
- `update-webssh2-dependency.yml`: `npm install --ignore-scripts`

Safety is already proven: CI has been building with `--ignore-scripts` since #110-era hardening, so the build demonstrably needs no lifecycle scripts. The `publish-npm` job needed no change — `package.json` has no `prepare`/`prepack`/`prepublishOnly` hooks, so `npm publish` ships the downloaded artifact without rebuilding.

## SC2 — published bundle becomes verifiable

The npm package ships a pre-built bundle (`client/public/**`) that is gitignored, so the shipped bytes never appear in any reviewable diff. Two changes make them independently checkable:

1. **Checksums published per release**: the `attach-assets` job now generates `checksums.txt` (SHA-256 of `client-public.zip` + every file in `client/public/`), attaches it as a release asset (machine-consumable, for gateway build validation), and appends the hashes to the release notes (human-glanceable, second surface an attacker must keep consistent).
2. **Reproducible builds**: the bundle banner embedded `new Date().toISOString()`, making every rebuild unique. It now embeds the git commit date, so rebuilding a tag yields byte-identical output. Verified locally: two consecutive builds produce identical SHA-256s for all bundle files.

Neither release assets nor notes are tamper-proof (both mutable with repo write access) — the tamper-evident anchor remains `npm publish --provenance`. The checksums make cross-channel comparison (npm vs GitHub release vs local rebuild) practical, which is what the gateway-side validation will consume.

## SC3 — `.npmrc` gitignore contradiction

`.gitignore` listed `.npmrc` while the file is intentionally tracked (`sign-git-tag=true`). Git ignores `.gitignore` for tracked files, so the entry did nothing except suggest token edits couldn't be committed — when they absolutely would be. Removed the entry and left a comment documenting the policy (no registry tokens ever; publishing is OIDC).

## Documentation

New **Release Artifact Integrity** section in `DOCS/SECURITY.md`: the threat model, all controls above, and copy-paste verification commands for consumers (`npm audit signatures`, checksum cross-check of an npm-installed copy against the GitHub release).

## Follow-up

A webssh2 gateway issue will track consuming `checksums.txt` during its build/CI to validate the bundled client.

## Test plan

- [x] `npm run check:all` — 328/328 tests, lint/format/typecheck clean
- [x] Built twice locally — byte-identical output (reproducibility verified)
- [x] Confirmed no `prepare`/`prepack`/`prepublishOnly` hooks exist (publish job unaffected by `--ignore-scripts` change)
- [ ] Next release run exercises the checksum generation + release-notes append