### PR TITLE
feat(security): attest release artifacts with sigstore provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -96,6 +98,17 @@ jobs:
             cat checksums.txt
             echo '```'
           } > checksums-notes.md
+
+      # Sigstore-signed provenance for the release assets. Makes
+      # checksums.txt tamper-evident (release assets are otherwise mutable
+      # with repo write access); verify with:
+      #   gh attestation verify checksums.txt --repo billchurch/webssh2_client
+      - name: Attest release artifacts
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            client-public.zip
+            checksums.txt
 
       - name: Attach assets to release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0

--- a/DOCS/SECURITY.md
+++ b/DOCS/SECURITY.md
@@ -79,8 +79,18 @@ curl -fsSL "https://github.com/billchurch/webssh2_client/releases/download/<tag>
 A mismatch means the npm artifact and the GitHub release disagree — treat
 as a compromise indicator until explained. Note that release assets and
 notes are mutable by anyone with repo write access; the tamper-evident
-anchor is npm provenance, and the checksums exist to make cross-channel
-comparison practical.
+anchors are npm provenance and the artifact attestations below — the
+checksums exist to make cross-channel comparison practical.
+
+- **Artifact attestations:** `client-public.zip` and `checksums.txt` are
+  signed with sigstore via `actions/attest-build-provenance`, recording in
+  a public transparency log which workflow and commit produced them. This
+  makes the checksum file itself tamper-evident. Verify with:
+
+```bash
+gh attestation verify checksums.txt --repo billchurch/webssh2_client
+gh attestation verify client-public.zip --repo billchurch/webssh2_client
+```
 
 - **Reproducible banner:** The bundle banner embeds the git commit date
   (not the build time), so rebuilding the same tag yields comparable output.


### PR DESCRIPTION
## Summary

Implements the "future enhancement" called out in billchurch/webssh2#547: the release job now signs `client-public.zip` and `checksums.txt` with `actions/attest-build-provenance`, producing sigstore attestations tied to the producing workflow + commit in a public transparency log.

## Why

#126 published `checksums.txt` per release so the webssh2 gateway can validate the bundled client. But GitHub release assets (and notes) are mutable by anyone with repo write access — so the checksum file was only as trustworthy as the release page itself. Attesting it closes that loop: tampering with the asset after the fact cannot forge the sigstore log entry, and the gateway's validation (webssh2#547) can require a valid attestation before trusting the checksums:

```bash
gh attestation verify checksums.txt --repo billchurch/webssh2_client
gh attestation verify client-public.zip --repo billchurch/webssh2_client
```

## Changes

- `release.yml` `attach-assets` job: new `actions/attest-build-provenance` step covering both assets, pinned to the v4.1.0 release commit SHA (`a2bbfa2`, verified against the tag; published 2026-02-26 — past the 14-day quarantine). Job permissions gain `id-token: write` + `attestations: write` (least-privilege additions required for OIDC signing).
- `DOCS/SECURITY.md`: attestation documented in the Release Artifact Integrity section with verify commands; tamper-evidence wording updated.

## Test plan

- [x] `npm run check:all` — clean (workflow + docs change only)
- [x] Action SHA verified: `v4.1.0` tag → `a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32`
- [ ] Next release run produces attestations (check the release's Attestations section / `gh attestation verify`)