### PR TITLE
fix(ci): repair checksum generation, move actions to node24, add asset backfill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -57,7 +57,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
+    inputs:
+      backfill_tag:
+        description: >-
+          Existing release tag to rebuild and re-attach assets for
+          (e.g. v5.1.0). Leave empty for a normal release-please run.
+        required: false
+        type: string
+        default: ''
 
 jobs:
   release-please:
@@ -17,7 +25,10 @@ jobs:
     steps:
       - name: Release Please
         id: release
-        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+        # Skipped in backfill mode so a pending release PR can't be
+        # released as a side effect of re-attaching old assets.
+        if: ${{ !inputs.backfill_tag }}
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
@@ -25,16 +36,30 @@ jobs:
   build:
     name: Build client
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: needs.release-please.outputs.release_created == 'true' || inputs.backfill_tag != ''
     runs-on: ubuntu-latest
     steps:
+      - name: Validate backfill tag
+        if: inputs.backfill_tag != ''
+        env:
+          BACKFILL_TAG: ${{ inputs.backfill_tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ ! "$BACKFILL_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+            echo "::error::backfill_tag '${BACKFILL_TAG}' is not a release tag (expected vX.Y.Z)"
+            exit 1
+          fi
+          # Require an existing release: action-gh-release would otherwise
+          # create a brand-new release for an arbitrary tag.
+          gh release view "$BACKFILL_TAG" --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName
+
       - name: Checkout tag
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          ref: ${{ inputs.backfill_tag || needs.release-please.outputs.tag_name }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -49,7 +74,7 @@ jobs:
         run: npm run build:server
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-output
           path: |
@@ -67,7 +92,7 @@ jobs:
       attestations: write
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: build-output
 
@@ -79,12 +104,12 @@ jobs:
 
       - name: Generate checksums
         env:
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+          TAG_NAME: ${{ inputs.backfill_tag || needs.release-please.outputs.tag_name }}
         run: |
           {
             echo "# webssh2_client ${TAG_NAME} SHA-256 checksums"
             sha256sum client-public.zip
-            cd client && find public -type f | LC_ALL=C sort | xargs sha256sum
+            (cd client && find public -type f | LC_ALL=C sort | xargs sha256sum)
           } > checksums.txt
           cat checksums.txt
           {
@@ -111,9 +136,9 @@ jobs:
             checksums.txt
 
       - name: Attach assets to release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
-          tag_name: ${{ needs.release-please.outputs.tag_name }}
+          tag_name: ${{ inputs.backfill_tag || needs.release-please.outputs.tag_name }}
           files: |
             client-public.zip
             checksums.txt
@@ -125,6 +150,9 @@ jobs:
   publish-npm:
     name: Publish to npm
     needs: [release-please, build]
+    # Never republish during an asset backfill; only run for a release
+    # that release-please created in this run.
+    if: needs.release-please.outputs.release_created == 'true' && !inputs.backfill_tag
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -136,14 +164,14 @@ jobs:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Download build artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: build-output
 


### PR DESCRIPTION
## Summary

- **Fix the v5.1.0 release failure** ([run 27410663170](https://github.com/billchurch/webssh2_client/actions/runs/27410663170)): the `{ ... } > checksums.txt` brace group runs in the current shell, so its trailing `cd client` leaked out; `cat checksums.txt` then ran from `client/` and failed under `bash -e`. The `cd` now runs in a subshell, preserving the `public/...` hash-path format that the verification recipe in `DOCS/SECURITY.md` greps for. Bug was introduced in #126; v5.1.0 was the first release to execute the step.
- **Node 24 action bumps** ahead of the 2026-06-16 forced migration off Node 20. All new pins are full commit SHAs, verified `runs.using: node24` at the pinned commit, and published ≥14 days ago (supply-chain quarantine policy):

| Action | From | To | Published |
| --- | --- | --- | --- |
| actions/setup-node | v4.4.0 | v6.4.0 | 2026-04-20 |
| actions/upload-artifact | v4.6.2 | v7.0.1 | 2026-04-10 |
| actions/download-artifact | v4.3.0 | v8.0.1 | 2026-03-11 |
| googleapis/release-please-action | v4.4.0 | v5.0.0 | 2026-04-22 |
| softprops/action-gh-release | v2.5.0 | v3.0.0 | 2026-04-12 |
| github/codeql-action/upload-sarif | v3.28.18 | v4.36.0 | 2026-05-22 |
| actions/dependency-review-action | v4.8.2 | v5.0.0 | 2026-05-08 |

  Notable: download-artifact v8 fails the run on digest mismatch by default (security win for this pipeline); setup-node v6 limits auto-caching to npm (we use `cache: 'npm'`, unaffected); release-please v5 / gh-release v3 / dep-review v5 are runtime-only majors. `actions/checkout` v5.0.1 and `attest-build-provenance` v4.1.0 (and its nested `actions/attest`) are already node24.
- **`workflow_dispatch` backfill mode**: a new optional `backfill_tag` input rebuilds an existing tag and re-attaches `client-public.zip`, `checksums.txt`, sigstore attestations, and the checksum release-notes appendix. Needed to backfill the missing v5.1.0 assets (npm publish succeeded; asset attach failed).

## Backfill safety design

- Tag is validated against `^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$` and checked to reference an **existing** release before checkout — prevents ref injection and prevents `action-gh-release` from creating a new release for an arbitrary tag.
- `release-please` is skipped in backfill mode so a pending release PR can't be released as a side effect.
- `publish-npm` is explicitly gated (`release_created == 'true' && !inputs.backfill_tag`) — previously it had no `if` and relied on the build job being skipped; in backfill mode it would have attempted a republish.
- Plain `workflow_dispatch` with an empty input behaves exactly as before.

## Test plan

- [x] Reproduced the brace-group `cd` leak locally with the exact script (same error, exit 1) and verified the subshell fix produces `checksums.txt` + `checksums-notes.md` at the workspace root with `public/...` paths
- [x] YAML validated and every `run:` block passes `bash -n`
- [x] Gating matrix walked for all four trigger cases (push/no-release, push/release, dispatch/empty, dispatch/backfill)
- [ ] After merge: dispatch Release with `backfill_tag=v5.1.0` to backfill the missing assets, then verify `gh attestation verify checksums.txt --repo billchurch/webssh2_client` and the SECURITY.md npm cross-check