### PR TITLE
feat: honor gateway-injected Socket.IO transports (#131)

### DIFF
--- a/client/src/services/socket.ts
+++ b/client/src/services/socket.ts
@@ -41,6 +41,8 @@ import {
   sanitizeClientAuthPayloadForLogging
 } from '../stores/config.js'
 import { createDebouncedResizeEmitter } from '../utils/terminalResize.js'
+import { readInjectedConfig } from '../utils/injected-config.js'
+import { resolveTransports } from '../utils/transports.js'
 import {
   RESIZE_DEBOUNCE_DELAY,
   DEFAULT_TERMINAL_COLS,
@@ -201,12 +203,16 @@ export class SocketService {
       query[key] = value
     }
 
+    const transports = resolveTransports(
+      readInjectedConfig()?.socket?.transports
+    )
+
     const newSocket = io(socketUrl, {
       path: socketPath,
       withCredentials: true,
       reconnection: false,
       timeout: 20000,
-      transports: ['websocket', 'polling'],
+      transports,
       query
     }) as Socket<ServerToClientEvents, ClientToServerEvents>
 

--- a/client/src/types/config.d.ts
+++ b/client/src/types/config.d.ts
@@ -66,6 +66,8 @@ export interface TerminalSettings {
 export interface WebSocketConfig {
   url: string | null
   path: string
+  /** Gateway-forced Socket.IO transport order (#131); omitted = client default */
+  transports?: string[]
 }
 
 export interface SSHConfigInput {

--- a/client/src/utils/transports.ts
+++ b/client/src/utils/transports.ts
@@ -1,0 +1,32 @@
+// client/src/utils/transports.ts
+// Resolver for the gateway-injected Socket.IO transport list (#131).
+//
+// The webssh2 gateway may inject `socket.transports` into the runtime
+// config so deployments behind WebSocket-blocking proxies can force
+// long-polling. The server validates the list before injecting; this
+// filter is the client-side safety net (the target environment is, by
+// definition, a meddling proxy).
+
+const VALID_TRANSPORTS = new Set(['websocket', 'polling'])
+
+export const DEFAULT_TRANSPORTS: readonly string[] = ['websocket', 'polling']
+
+/**
+ * Whitelist-filter an injected transport list.
+ *
+ * Returns the filtered, deduped list when at least one valid entry
+ * survives; otherwise returns the websocket-first default. Never
+ * returns an empty array (with `reconnection: false` an empty list
+ * yields a socket that can never connect).
+ */
+export function resolveTransports(injected: unknown): string[] {
+  if (!Array.isArray(injected)) {
+    return [...DEFAULT_TRANSPORTS]
+  }
+  const filtered = injected.filter(
+    (entry): entry is string =>
+      typeof entry === 'string' && VALID_TRANSPORTS.has(entry)
+  )
+  const deduped = [...new Set(filtered)]
+  return deduped.length > 0 ? deduped : [...DEFAULT_TRANSPORTS]
+}

--- a/tests/transports.test.js
+++ b/tests/transports.test.js
@@ -1,0 +1,75 @@
+/**
+ * Tests for the injected Socket.IO transport resolver (#131).
+ *
+ * The gateway may inject socket.transports into the runtime config. The
+ * client whitelist-filters it (defense in depth: the target environment
+ * is a meddling proxy) and falls back to the websocket-first default
+ * whenever the injected value is absent, malformed, or empties out
+ * after filtering.
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+await register('./tests/ts-loader.mjs', pathToFileURL('./'))
+
+const { resolveTransports, DEFAULT_TRANSPORTS } =
+  await import('../client/src/utils/transports.ts')
+
+describe('resolveTransports', () => {
+  it('returns the websocket-first default when nothing is injected', () => {
+    assert.deepStrictEqual(resolveTransports(undefined), [
+      'websocket',
+      'polling'
+    ])
+    assert.deepStrictEqual(resolveTransports(null), ['websocket', 'polling'])
+  })
+
+  it('honors a valid injected list, preserving order', () => {
+    assert.deepStrictEqual(resolveTransports(['polling']), ['polling'])
+    assert.deepStrictEqual(resolveTransports(['polling', 'websocket']), [
+      'polling',
+      'websocket'
+    ])
+  })
+
+  it('filters unknown transports, keeping valid ones in order', () => {
+    assert.deepStrictEqual(
+      resolveTransports(['carrier-pigeon', 'polling', 'webtransport']),
+      ['polling']
+    )
+  })
+
+  it('drops non-string entries', () => {
+    assert.deepStrictEqual(resolveTransports([42, 'polling', {}]), ['polling'])
+  })
+
+  it('dedupes while preserving first occurrence order', () => {
+    assert.deepStrictEqual(
+      resolveTransports(['polling', 'polling', 'websocket']),
+      ['polling', 'websocket']
+    )
+  })
+
+  it('falls back to the default when the list empties after filtering', () => {
+    assert.deepStrictEqual(resolveTransports([]), ['websocket', 'polling'])
+    assert.deepStrictEqual(resolveTransports(['smoke-signal']), [
+      'websocket',
+      'polling'
+    ])
+  })
+
+  it('falls back to the default for non-array input', () => {
+    assert.deepStrictEqual(resolveTransports('polling'), [
+      'websocket',
+      'polling'
+    ])
+  })
+
+  it('returns a fresh array, never the DEFAULT_TRANSPORTS reference', () => {
+    const result = resolveTransports(undefined)
+    assert.notStrictEqual(result, DEFAULT_TRANSPORTS)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #131. The client now honors a gateway-injected Socket.IO transport list
(`socket.transports` on the runtime config), enabling long-polling fallback for
deployments behind WebSocket-blocking proxies — with a whitelist filter as
defense in depth and zero behavior change for existing deployments.

This is the client half of the cross-repo feature; the server half
(injection of `options.transport` / `WEBSSH2_OPTIONS_TRANSPORT`) is
billchurch/webssh2#549.

## Contract

| Injected `socket.transports` | Client behavior |
| --- | --- |
| absent | default `['websocket', 'polling']` (websocket-first, unchanged) |
| `['polling']` | long-polling only |
| `['polling', 'websocket']` | polling-first, upgrade when possible |
| invalid / empties after filtering | default (never an empty array) |

- Whitelist exactly `{websocket, polling}`; order-significant; first-occurrence
  dedupe.
- `resolveTransports` never returns an empty array — with `reconnection: false`
  an empty transport list is a socket that can never connect.
- Client-side filtering is a safety net on top of server-side validation: the
  target environment is by definition a meddling proxy.

## Changes

- `client/src/utils/transports.ts` (new): pure `resolveTransports` +
  `DEFAULT_TRANSPORTS`.
- `client/src/services/socket.ts`: `io()` now receives
  `resolveTransports(readInjectedConfig()?.socket?.transports)`; all other
  options unchanged.
- `client/src/types/config.d.ts`: `WebSocketConfig.transports?: string[]`.
- `tests/transports.test.js` (new): 8 cases (default, order, filtering,
  non-string entries, dedupe, empty-after-filter, non-array, fresh-array).

## Testing

- Full suite: 355/355 passing (`node --test`); `npm run check:all` clean.
- Independent final review re-ran suite (361/361 incl. new tests), typecheck,
  and eslint — clean; adversarial injection review found no path where a
  malicious injected value reaches `io()` unfiltered.
- End-to-end proof (forced polling via a real gateway) lands in
  billchurch/webssh2 as a Playwright spec once this ships in a release and the
  server pins it (see billchurch/webssh2#549).

## Release note

Once merged, this should go out as **v5.3.0**; webssh2 then pins 5.3.0 and adds
the transport E2E.
