### PR TITLE
fix(deps): remove orphaned @rollup/rollup-linux-x64-gnu optionalDependency

### DIFF
--- a/2026-06-10-webssh2_client-red-team.md
+++ b/2026-06-10-webssh2_client-red-team.md
@@ -263,6 +263,10 @@ covers Linux x64. Build fragility, not security.
 the lockfile; if a CI arch needs a guaranteed binary, pin it to the exact resolved
 rollup version and bump both together.
 
+**Status:** Resolved 2026-07-30 (#143) — the `optionalDependencies` block was
+removed. Rollup left the dependency tree entirely with the Vite 8 / Rolldown
+migration (#140), so no replacement pin is needed.
+
 ---
 
 ## Supply-chain / Build
@@ -451,7 +455,7 @@ direction so re-sort happens only when inputs change.
 | SC5 | Supply-chain | MEDIUM     | Filed [#117](https://github.com/billchurch/webssh2_client/issues/117) — fix stale `csp-config.ts` ref + `webssh2Config` CSP-readiness (header = gateway work)                                                                                                                           |
 | S6  | Security     | LOW        | Open — optional client-side fingerprint recompute                                                                                                                                                                                                                                       |
 | A3  | Availability | LOW        | Open — surface failed-integrity downloads to user                                                                                                                                                                                                                                       |
-| A4  | Availability | LOW        | Open — drop manual rollup native-binary pin                                                                                                                                                                                                                                             |
+| A4  | Availability | LOW        | Resolved (#143) — orphaned optionalDependencies entry removed                                                                                                                                                                                                                           |
 | SC6 | Supply-chain | LOW        | Filed [#116](https://github.com/billchurch/webssh2_client/issues/116) — exact-version comments on SHA-pinned actions                                                                                                                                                                    |
 | SC7 | Supply-chain | LOW        | Merged [PR #119](https://github.com/billchurch/webssh2_client/pull/119) — type-aware lint + `no-unsafe-*` at error, 10 fixed; SBE ratchet → [#118](https://github.com/billchurch/webssh2_client/issues/118)                                                                             |
 | P1  | Performance  | LOW        | Open — memoize sorted directory listing                                                                                                                                                                                                                                                 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,9 +47,6 @@
       },
       "engines": {
         "node": ">= 22"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.53.3"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -1438,19 +1435,6 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
-      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.12",

--- a/package.json
+++ b/package.json
@@ -106,8 +106,5 @@
     "tmp": ">=0.2.6",
     "axios": ">=1.16.1",
     "chromedriver": "148.0.2"
-  },
-  "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "^4.53.3"
   }
 }


### PR DESCRIPTION
## Summary

Removes the orphaned `optionalDependencies` entry for
`@rollup/rollup-linux-x64-gnu` (fixes #143).

The entry was the npm optional-deps CI workaround from the Rollup/Vite 7
era. Since the Vite 8 / Rolldown migration (#140), `rollup` is entirely
absent from the dependency tree — the only rollup-related lockfile entry
was the orphaned binary itself — so every downstream
`npm install webssh2_client` on linux-x64 pulled an unused native binary
(unnecessary supply-chain surface, observed surviving into the webssh2
server lockfile via the client tarball during billchurch/webssh2#550
review).

## Changes

- `package.json`: drop the `optionalDependencies` block
- `package-lock.json`: regenerated; `@rollup/rollup-linux-x64-gnu` entry
  removed
- `2026-06-10-webssh2_client-red-team.md`: mark finding A4 as resolved
  (it flagged this exact pin)

## Verification

- Remaining `rollup` mentions in the lockfile are only
  `rollup-plugin-visualizer` (dep of dev-only `vite-bundle-visualizer`),
  which lists `rollup` as an *optional* peer — nothing resolves it
- `npm run build` succeeds (Vite 8 / Rolldown)
- `npm test`: 361 pass, 0 fail
- `prettier --check` clean on changed files; markdownlint MD013 table-row
  violations in the red-team doc are pre-existing (identical on the
  pristine file)

## Follow-up (not in this PR)

After the 5.4.1 release, bump `webssh2_client` in the webssh2 server and
refresh its lockfile so the entry stops arriving via the client tarball.
