### PR TITLE
chore(deps): drop orphaned serialize-javascript override, adopt vite 8.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "stylelint-config-standard": "^40.0.0",
         "tailwindcss": "3.4.13",
         "typescript": "^5.9.3",
-        "vite": "^8.1.4",
+        "vite": "^8.1.5",
         "vite-bundle-visualizer": "^1.2.1",
         "vite-plugin-solid": "^2.11.12"
       },
@@ -7557,16 +7557,16 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "stylelint-config-standard": "^40.0.0",
     "tailwindcss": "3.4.13",
     "typescript": "^5.9.3",
-    "vite": "^8.1.4",
+    "vite": "^8.1.5",
     "vite-bundle-visualizer": "^1.2.1",
     "vite-plugin-solid": "^2.11.12"
   },
@@ -102,7 +102,6 @@
     ]
   },
   "overrides": {
-    "serialize-javascript": ">=7.0.3",
     "tmp": ">=0.2.6",
     "axios": ">=1.16.1",
     "chromedriver": "148.0.2"


### PR DESCRIPTION
## Summary

Post-#143 dependency hygiene, found while auditing the release surface for
5.4.1:

1. **Drop orphaned `serialize-javascript` override** — the `>=7.0.3` entry
   matches nothing in the dependency tree (zero lockfile entries,
   `npm ls serialize-javascript` finds no instance). Dead weight left
   behind by an earlier dependency update, same class of leftover as
   #143. The remaining overrides (`tmp`, `axios`, `chromedriver`) are all
   still active.
2. **Adopt vite 8.1.5** — published 2026-07-16 06:51Z, so it aged out of
   the 14-day supply-chain quarantine on 2026-07-30. Dev-only; the
   rebuilt production bundle is **byte-identical** to the 8.1.4 build, so
   `client/public/` is untouched.

## Verification

- `npm ls vite` resolves 8.1.5 (deduped everywhere)
- `grep -c serialize-javascript package-lock.json` → 0
- `npm run build` — bundle byte-identical (no `client/public/` diff)
- `npm test` — 361 pass, 0 fail
- `npm run typecheck` — clean
- `npm audit` — 0 vulnerabilities

## Notes

- No release needed for this on its own (chore; bundle unchanged) — it
  rides the next release.
- `lightningcss 1.33.0` stays quarantined until ~2026-08-03 (not touched
  here).
