### PR TITLE
fix(sftp): surface pre-transfer server rejections on queued transfers

### DIFF
--- a/client/src/services/sftp-service.ts
+++ b/client/src/services/sftp-service.ts
@@ -504,15 +504,29 @@ function handleError(response: SftpErrorResponse): void {
   const error = new Error(response.message)
 
   // Update transfer status if applicable
+  let transferMatched = false
   if (response.transferId) {
     const transfer = activeTransfers.get(response.transferId)
     if (transfer) {
+      transferMatched = true
       transfer.status = 'failed'
       transfer.error = response.message
     }
 
     // Reject any pending promises for this transfer
     rejectAllForTransfer(response.transferId, error)
+  }
+
+  // Pre-transfer rejection (e.g. blocked extension): the server refused the
+  // upload/download before sending a ready response, so the transfer was
+  // never registered in activeTransfers and the awaiting promise lives in
+  // the FIFO ready queue, not in pendingRequests
+  if (
+    !transferMatched &&
+    (response.operation === 'upload' || response.operation === 'download') &&
+    rejectPendingReady(response.operation, error)
+  ) {
+    return
   }
 
   // Reject operation-specific requests by path if provided
@@ -545,6 +559,28 @@ function handleError(response: SftpErrorResponse): void {
       rejectPendingByPrefix(prefix, error)
     }
   }
+}
+
+/**
+ * Reject the oldest queued upload/download ready promise. The server
+ * responds to start requests in order, so the FIFO head is the request
+ * this error belongs to — mirroring how the success path consumes the
+ * queue in the sftp-upload-ready / sftp-download-ready handlers.
+ */
+function rejectPendingReady(
+  operation: 'upload' | 'download',
+  error: Error
+): boolean {
+  const pending =
+    operation === 'upload'
+      ? pendingUploadReady.shift()
+      : pendingDownloadReady.shift()
+  if (!pending) {
+    return false
+  }
+  clearTimeout(pending.timeoutId)
+  pending.reject(error)
+  return true
 }
 
 /**

--- a/tests/sftp-error-correlation.test.js
+++ b/tests/sftp-error-correlation.test.js
@@ -1,0 +1,171 @@
+/**
+ * Regression tests for issue #147:
+ *
+ * An `sftp-error` that arrives BEFORE the upload/download ready response
+ * (e.g. server rejects a blocked file extension pre-transfer) must reject
+ * the pending ready promise with the server-provided message. Previously
+ * the error was only correlated against `activeTransfers` and the
+ * `pendingRequests` map — never the `pendingUploadReady` /
+ * `pendingDownloadReady` FIFO queues — so the transfer sat at
+ * "Waiting... 0%" until the generic 30s "Upload ready timeout" fired.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { register } from 'node:module'
+import { pathToFileURL } from 'node:url'
+import { JSDOM } from 'jsdom'
+
+await register('./tests/ts-loader.mjs', pathToFileURL('./'))
+
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+  url: 'http://localhost/'
+})
+globalThis.window = dom.window
+globalThis.document = dom.window.document
+globalThis.localStorage = dom.window.localStorage
+
+const { setSocket } = await import('../client/src/services/socket.ts')
+const { uploadFile, downloadFile, cleanupSftpListeners } =
+  await import('../client/src/services/sftp-service.ts')
+
+/** Minimal fake Socket.IO socket: records emits, lets tests inject events */
+function createFakeSocket() {
+  const handlers = new Map()
+  const emitted = []
+  return {
+    on(event, handler) {
+      handlers.set(event, handler)
+    },
+    off(event) {
+      handlers.delete(event)
+    },
+    emit(event, payload) {
+      emitted.push({ event, payload })
+    },
+    /** Simulate a server -> client event */
+    receive(event, payload) {
+      const handler = handlers.get(event)
+      assert.ok(handler, `no listener registered for ${event}`)
+      handler(payload)
+    },
+    emitted
+  }
+}
+
+/**
+ * Await a promise but give up after `ms`; returns the rejection message,
+ * 'resolved', or 'still-pending'.
+ */
+function settlementWithin(promise, ms = 200) {
+  return Promise.race([
+    promise.then(
+      () => 'resolved',
+      (err) => err.message
+    ),
+    new Promise((resolve) => {
+      setTimeout(() => resolve('still-pending'), ms).unref?.()
+    })
+  ])
+}
+
+async function waitFor(condition, timeoutMs = 1000) {
+  const start = Date.now()
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('waitFor timed out')
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}
+
+describe('sftp-error correlation for pre-transfer rejections (issue #147)', () => {
+  let fakeSocket
+
+  beforeEach(() => {
+    fakeSocket = createFakeSocket()
+    setSocket(fakeSocket)
+  })
+
+  afterEach(() => {
+    // Clears FIFO queues, pending requests, and their timeouts so the
+    // test process is not held open by the 30s ready timeouts
+    cleanupSftpListeners()
+    setSocket(null)
+  })
+
+  it('rejects a pending upload with the server message when sftp-error arrives before sftp-upload-ready', async () => {
+    const file = new File([new Uint8Array(16)], 'malicious.exe', {
+      type: 'application/octet-stream'
+    })
+
+    const upload = uploadFile(file, '/home/testuser/malicious.exe')
+
+    // The upload-start frame is emitted before awaiting the ready response
+    assert.strictEqual(fakeSocket.emitted[0].event, 'sftp-upload-start')
+
+    // Server rejects pre-transfer: transferId is set but the client never
+    // saw it (no sftp-upload-ready was sent)
+    fakeSocket.receive('sftp-error', {
+      operation: 'upload',
+      code: 'SFTP_EXTENSION_BLOCKED',
+      message: 'File extension .exe is not allowed',
+      path: '/home/testuser/malicious.exe',
+      transferId: '7f349eb1-bf1b-4a0c-be6b-befbf71eeb86',
+      fileName: 'malicious.exe'
+    })
+
+    assert.strictEqual(
+      await settlementWithin(upload),
+      'File extension .exe is not allowed'
+    )
+  })
+
+  it('rejects a pending download with the server message when sftp-error arrives before sftp-download-ready', async () => {
+    const download = downloadFile('/home/testuser/secret.txt')
+
+    assert.strictEqual(fakeSocket.emitted[0].event, 'sftp-download-start')
+
+    fakeSocket.receive('sftp-error', {
+      operation: 'download',
+      code: 'SFTP_PATH_BLOCKED',
+      message: 'Path is not allowed',
+      path: '/home/testuser/secret.txt',
+      transferId: '11111111-2222-3333-4444-555555555555'
+    })
+
+    assert.strictEqual(await settlementWithin(download), 'Path is not allowed')
+  })
+
+  it('does not reject a queued upload when the error belongs to an active transfer', async () => {
+    const fileA = new File([new Uint8Array(16)], 'a.bin')
+    const uploadA = uploadFile(fileA, '/home/testuser/a.bin')
+
+    // Server accepts upload A; it becomes an active transfer
+    fakeSocket.receive('sftp-upload-ready', {
+      transferId: 'transfer-a',
+      chunkSize: 32768
+    })
+
+    // Wait until A has sent its first chunk (it is now mid-transfer)
+    await waitFor(() =>
+      fakeSocket.emitted.some((e) => e.event === 'sftp-upload-chunk')
+    )
+
+    // Upload B is now queued, waiting for its own ready response
+    const fileB = new File([new Uint8Array(16)], 'b.bin')
+    const uploadB = uploadFile(fileB, '/home/testuser/b.bin')
+
+    // Mid-transfer failure for A must not consume B's queued ready promise
+    fakeSocket.receive('sftp-error', {
+      operation: 'upload',
+      code: 'SFTP_WRITE_FAILED',
+      message: 'disk full',
+      path: '/home/testuser/a.bin',
+      transferId: 'transfer-a'
+    })
+
+    assert.strictEqual(await settlementWithin(uploadA), 'disk full')
+    assert.strictEqual(await settlementWithin(uploadB), 'still-pending')
+  })
+})

--- a/tests/ts-loader.mjs
+++ b/tests/ts-loader.mjs
@@ -6,6 +6,16 @@ export async function resolve(specifier, context, defaultResolve) {
     const url = new URL(specifier, context.parentURL)
     return { shortCircuit: true, url: url.href }
   }
+  // Extensionless relative imports (Vite resolves these; Node does not)
+  if (specifier.startsWith('.') && !/\.[a-z]+$/i.test(specifier)) {
+    const tsCandidate = new URL(`${specifier}.ts`, context.parentURL)
+    try {
+      await readFile(tsCandidate)
+      return { shortCircuit: true, url: tsCandidate.href }
+    } catch {
+      // fall back to default resolution
+    }
+  }
   if (specifier.endsWith('.js')) {
     const tsCandidate = new URL(
       specifier.replace(/\.js$/, '.ts'),


### PR DESCRIPTION
## Summary

Fixes #147 — an `sftp-error` arriving before the upload/download ready
response (e.g. a blocked file extension rejected pre-transfer) left the
transfer stuck at "Waiting... 0%" and the server's real error message
("File extension .exe is not allowed") never rendered.

## Root cause

`handleError()` in `client/src/services/sftp-service.ts` correlated errors
against `activeTransfers` and the `pendingRequests` map only. But a
pre-transfer rejection happens before the transfer is registered in
`activeTransfers`, and the awaiting ready promise lives in the
`pendingUploadReady` / `pendingDownloadReady` FIFO queues — which
`handleError()` never inspected. The promise only failed via its generic
30s "Upload ready timeout".

## Fix

When an `sftp-error` for `operation: 'upload' | 'download'` does not match
an active transfer, reject the oldest queued ready promise with the
server-provided message. The server responds to start requests in order,
so the FIFO head is the request the error belongs to — mirroring how the
success path (`sftp-upload-ready` / `sftp-download-ready`) consumes the
same queue. The rejection flows into `sftp-store`'s existing catch block,
which marks the placeholder transfer `failed` with the real message.

## Tests

New `tests/sftp-error-correlation.test.js` (exercises the real service
against a fake socket, JSDOM):

- upload rejected pre-transfer surfaces the server message
- download rejected pre-transfer surfaces the server message
- guard: a mid-transfer error for an active transfer does not consume a
  different upload's queued ready promise

Also extends `tests/ts-loader.mjs` to resolve extensionless relative
imports (Vite resolves these; Node's loader did not), needed to import
the service module graph in tests.

## Verification

- `npm run check:all` — 364 tests pass, lint/typecheck clean
- webssh2 E2E `e2e-sftp.spec.ts -g "blocked extensions"` (previously red,
  tracked as Task 6 of webssh2#567) now passes against this client build
